### PR TITLE
라이벌리 생성 기능 구현

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-security")
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("org.springframework.boot:spring-boot-starter-webflux")
+	implementation("org.springframework.boot:spring-boot-starter-validation")
 
 	implementation("io.hypersistence:hypersistence-utils-hibernate-63:3.7.3")
 	testImplementation("org.testcontainers:testcontainers:1.19.7")

--- a/api/src/main/java/com/glennsyj/rivals/api/riot/repository/RiotAccountRepository.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/riot/repository/RiotAccountRepository.java
@@ -1,10 +1,12 @@
 package com.glennsyj.rivals.api.riot.repository;
 
 import com.glennsyj.rivals.api.riot.entity.RiotAccount;
+import com.glennsyj.rivals.api.rivalry.entity.Rivalry;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -12,4 +14,5 @@ public interface RiotAccountRepository extends JpaRepository<RiotAccount, Long> 
     // 추후 성능 상 문제 발생할 시: Projection 변경 고려 (조회용)
     Optional<RiotAccount> findByGameNameAndTagLine(String gameName, String tagLine);
     Optional<RiotAccount> findByPuuid(String puuid);
+    List<RiotAccount> findAllByIdIn(List<Long> ids);
 }

--- a/api/src/main/java/com/glennsyj/rivals/api/rivalry/controller/RivalryController.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/rivalry/controller/RivalryController.java
@@ -1,0 +1,35 @@
+package com.glennsyj.rivals.api.rivalry.controller;
+
+import com.glennsyj.rivals.api.rivalry.model.RivalryCreationDto;
+import com.glennsyj.rivals.api.rivalry.model.RivalryResultDto;
+import com.glennsyj.rivals.api.rivalry.service.RivalryService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/api/v1/rivalries")
+public class RivalryController {
+
+    private RivalryService rivalryService;
+
+    public RivalryController(RivalryService rivalryService) {
+        this.rivalryService = rivalryService;
+    }
+
+    @PostMapping("")
+    public ResponseEntity<?> createRivalry(@Valid @RequestBody RivalryCreationDto creationDto) {
+
+        Long rivalryId = rivalryService.createRivalryFrom(creationDto);
+        RivalryResultDto response = new RivalryResultDto(rivalryId);
+
+        URI uri = URI.create("/api/v1/rivalries/" + rivalryId);
+
+        return ResponseEntity.created(uri).body(response);
+    }
+}

--- a/api/src/main/java/com/glennsyj/rivals/api/rivalry/entity/RivalSide.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/rivalry/entity/RivalSide.java
@@ -1,0 +1,5 @@
+package com.glennsyj.rivals.api.rivalry.entity;
+
+public enum RivalSide {
+    LEFT, RIGHT
+}

--- a/api/src/main/java/com/glennsyj/rivals/api/rivalry/entity/Rivalry.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/rivalry/entity/Rivalry.java
@@ -1,0 +1,44 @@
+package com.glennsyj.rivals.api.rivalry.entity;
+
+import io.hypersistence.utils.hibernate.id.Tsid;
+import jakarta.persistence.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name="rivalries")
+@EntityListeners(AuditingEntityListener.class)
+public class Rivalry {
+
+    @Id
+    @Tsid
+    private Long id;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    // 소환사의 협곡 랭크로 확장 시 고려
+    // 각 Side 마다 특정 인원이 동시에 포함된 비교가 필요할 수 있으므로 Set 대신 List
+    @OneToMany(mappedBy = "rivalry")
+    private List<RivalryParticipant> participants = new ArrayList<>();
+
+    protected Rivalry() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public List<RivalryParticipant> getParticipants() {
+        return participants;
+    }
+}

--- a/api/src/main/java/com/glennsyj/rivals/api/rivalry/entity/Rivalry.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/rivalry/entity/Rivalry.java
@@ -27,7 +27,7 @@ public class Rivalry {
     @OneToMany(mappedBy = "rivalry")
     private List<RivalryParticipant> participants = new ArrayList<>();
 
-    protected Rivalry() {
+    public Rivalry() {
     }
 
     public void addParticipant(RivalryParticipant participant) {

--- a/api/src/main/java/com/glennsyj/rivals/api/rivalry/entity/Rivalry.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/rivalry/entity/Rivalry.java
@@ -30,6 +30,15 @@ public class Rivalry {
     protected Rivalry() {
     }
 
+    public void addParticipant(RivalryParticipant participant) {
+        if (!isDuplicatedOnSameSide(participant)) {
+            participants.add(participant);
+            participant.participate(this);
+        } else {
+            throw new IllegalArgumentException("Participant already exists on the same side.");
+        }
+    }
+
     public Long getId() {
         return id;
     }
@@ -40,5 +49,15 @@ public class Rivalry {
 
     public List<RivalryParticipant> getParticipants() {
         return participants;
+    }
+
+    private boolean isDuplicatedOnSameSide(RivalryParticipant participant) {
+        for (RivalryParticipant p : participants) {
+            if (p.getRiotAccount().equals(participant.getRiotAccount()) &&
+                    p.getSide() == participant.getSide()) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/api/src/main/java/com/glennsyj/rivals/api/rivalry/entity/RivalryParticipant.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/rivalry/entity/RivalryParticipant.java
@@ -40,6 +40,10 @@ public class RivalryParticipant {
         this.side = side;
     }
 
+    public void participate(Rivalry rivalry) {
+        this.rivalry = rivalry;
+    }
+
     // Getters and Setters
     public Long getId() {
         return id;

--- a/api/src/main/java/com/glennsyj/rivals/api/rivalry/entity/RivalryParticipant.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/rivalry/entity/RivalryParticipant.java
@@ -1,0 +1,63 @@
+package com.glennsyj.rivals.api.rivalry.entity;
+
+import com.glennsyj.rivals.api.riot.entity.RiotAccount;
+import io.hypersistence.utils.hibernate.id.Tsid;
+import jakarta.persistence.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "rivalry_participants")
+public class RivalryParticipant {
+
+    @Id
+    @Tsid
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "riot_account_id", nullable = false)
+    private RiotAccount riotAccount;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "rivalry_id", nullable = false)
+    private Rivalry rivalry;
+
+    @Enumerated(EnumType.STRING)
+    private RivalSide side;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    protected RivalryParticipant() {}
+
+    public RivalryParticipant(RiotAccount riotAccount, Rivalry rivalry, RivalSide side) {
+        this.riotAccount = riotAccount;
+        this.rivalry = rivalry;
+        this.side = side;
+    }
+
+    // Getters and Setters
+    public Long getId() {
+        return id;
+    }
+
+    public RiotAccount getRiotAccount() {
+        return riotAccount;
+    }
+
+    public Rivalry getRivalry() {
+        return rivalry;
+    }
+
+    public RivalSide getSide() {
+        return side;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/api/src/main/java/com/glennsyj/rivals/api/rivalry/model/RivalryCreationDto.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/rivalry/model/RivalryCreationDto.java
@@ -1,8 +1,25 @@
 package com.glennsyj.rivals.api.rivalry.model;
 
+import com.glennsyj.rivals.api.rivalry.entity.RivalSide;
+import jakarta.validation.constraints.NotEmpty;
+
 import java.util.List;
 
 public record RivalryCreationDto(
-    List<RivalryParticipantDto> participants
+        @NotEmpty(message="participants should not be empty")
+        List<RivalryParticipantDto> participants
 ) {
+    public RivalryCreationDto {
+
+        // LEFT SIDE와 RIGHT SIDE에 최소한 하나의 참여자는 있도록 함
+        boolean hasLeft = participants.stream()
+                .anyMatch(p -> p.side() == RivalSide.LEFT);
+        boolean hasRight = participants.stream()
+                .anyMatch(p -> p.side() == RivalSide.RIGHT);
+
+        if (!hasLeft || !hasRight) {
+            throw new IllegalArgumentException(
+                    "At least one participant required for each side (LEFT and RIGHT)");
+        }
+    }
 }

--- a/api/src/main/java/com/glennsyj/rivals/api/rivalry/model/RivalryCreationDto.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/rivalry/model/RivalryCreationDto.java
@@ -1,0 +1,8 @@
+package com.glennsyj.rivals.api.rivalry.model;
+
+import java.util.List;
+
+public record RivalryCreationDto(
+    List<RivalryParticipantDto> participants
+) {
+}

--- a/api/src/main/java/com/glennsyj/rivals/api/rivalry/model/RivalryParticipantDto.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/rivalry/model/RivalryParticipantDto.java
@@ -1,0 +1,17 @@
+package com.glennsyj.rivals.api.rivalry.model;
+
+import com.glennsyj.rivals.api.rivalry.entity.RivalryParticipant;
+import com.glennsyj.rivals.api.rivalry.entity.RivalSide;
+
+
+public record RivalryParticipantDto(
+    Long id,
+    RivalSide side) {
+
+    public static RivalryParticipantDto from(RivalryParticipant participant) {
+        return new RivalryParticipantDto(
+                participant.getId(),
+                participant.getSide()
+        );
+    }
+}

--- a/api/src/main/java/com/glennsyj/rivals/api/rivalry/model/RivalryResultDto.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/rivalry/model/RivalryResultDto.java
@@ -1,0 +1,6 @@
+package com.glennsyj.rivals.api.rivalry.model;
+
+public record RivalryResultDto(
+        Long rivalryId
+) {
+}

--- a/api/src/main/java/com/glennsyj/rivals/api/rivalry/repository/RivalryRepository.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/rivalry/repository/RivalryRepository.java
@@ -1,0 +1,13 @@
+package com.glennsyj.rivals.api.rivalry.repository;
+
+import com.glennsyj.rivals.api.rivalry.entity.Rivalry;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RivalryRepository extends JpaRepository<Rivalry, Long> {
+
+    Optional<Rivalry> findRivalryById(Long id);
+}

--- a/api/src/main/java/com/glennsyj/rivals/api/rivalry/service/RivalryService.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/rivalry/service/RivalryService.java
@@ -1,0 +1,65 @@
+package com.glennsyj.rivals.api.rivalry.service;
+
+import com.glennsyj.rivals.api.riot.entity.RiotAccount;
+import com.glennsyj.rivals.api.riot.repository.RiotAccountRepository;
+import com.glennsyj.rivals.api.rivalry.entity.Rivalry;
+import com.glennsyj.rivals.api.rivalry.entity.RivalryParticipant;
+import com.glennsyj.rivals.api.rivalry.model.RivalryCreationDto;
+import com.glennsyj.rivals.api.rivalry.model.RivalryParticipantDto;
+import com.glennsyj.rivals.api.rivalry.repository.RivalryRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.HashMap;
+import java.util.List;
+
+@Service
+public class RivalryService {
+
+    private RivalryRepository rivalryRepository;
+    private RiotAccountRepository riotAccountRepository;
+
+    public RivalryService(RivalryRepository rivalryRepository, RiotAccountRepository riotAccountRepository) {
+        this.rivalryRepository = rivalryRepository;
+        this.riotAccountRepository = riotAccountRepository;
+    }
+
+    @Transactional
+    public Long createRivalryFrom(RivalryCreationDto creationDto) {
+
+        List<Long> accountIds = creationDto.participants().stream()
+                .map((RivalryParticipantDto::id))
+                .toList();
+
+        List<RiotAccount> accounts = riotAccountRepository.findAllByIdIn(accountIds);
+
+        // 중간 검증: account를 하나도 찾을 수 없을 시
+        if (accounts.isEmpty()) {
+            throw new IllegalArgumentException("Some of accounts not found");
+        }
+
+        HashMap<Long, RiotAccount> accountMap = new HashMap<>();
+
+        for (RiotAccount account : accounts) {
+            accountMap.put(account.getId(), account);
+        }
+
+        Rivalry rivalry = new Rivalry();
+
+        for (RivalryParticipantDto dto : creationDto.participants()) {
+            RivalryParticipant participant = new RivalryParticipant(
+                    accountMap.get(dto.id()), rivalry, dto.side()
+            );
+            rivalry.addParticipant(participant);
+        }
+
+        rivalry = rivalryRepository.save(rivalry);
+
+        // 최종 검증: dto 내 participant 수와 영속화된 participant 수 비교
+        if (accountIds.size() != rivalry.getParticipants().size()) {
+            throw new IllegalArgumentException("Some of accounts not found");
+        }
+
+        return rivalry.getId();
+    }
+}

--- a/api/src/test/java/com/glennsyj/rivals/api/config/EntityTestUtil.java
+++ b/api/src/test/java/com/glennsyj/rivals/api/config/EntityTestUtil.java
@@ -1,0 +1,21 @@
+package com.glennsyj.rivals.api.config;
+
+import java.lang.reflect.Field;
+
+public class EntityTestUtil {
+
+    public static void setFieldWithValue(Object entity, String fieldName, Object value) {
+        try {
+            Field field = entity.getClass().getDeclaredField(fieldName);
+            field.setAccessible(true);
+            field.set(entity, value);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to set id via reflection", e);
+        }
+    }
+
+    // 편의를 위한 단축 메서드
+    public static void setId(Object entity, Object value) {
+        setFieldWithValue(entity, "id", value);
+    }
+}

--- a/api/src/test/java/com/glennsyj/rivals/api/rival/repository/RivalryRepositoryTest.java
+++ b/api/src/test/java/com/glennsyj/rivals/api/rival/repository/RivalryRepositoryTest.java
@@ -1,0 +1,51 @@
+package com.glennsyj.rivals.api.rival.repository;
+
+import com.glennsyj.rivals.api.config.TestContainerConfig;
+import com.glennsyj.rivals.api.riot.entity.RiotAccount;
+import com.glennsyj.rivals.api.rivalry.entity.RivalSide;
+import com.glennsyj.rivals.api.rivalry.entity.Rivalry;
+import com.glennsyj.rivals.api.rivalry.entity.RivalryParticipant;
+import com.glennsyj.rivals.api.rivalry.repository.RivalryRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Import(TestContainerConfig.class)
+@Testcontainers
+public class RivalryRepositoryTest {
+
+    @Autowired
+    private RivalryRepository rivalryRepository;
+
+    /*
+        Rivalry 엔티티 행위 및
+        RivalryParticipantRepository 필요 여부 확인 위한 테스트
+     */
+    @Test
+    void 라이벌리를_생성하고_참여자를_추가하면_참여자도_영속화한다() {
+
+        // given
+        Rivalry rivalry = new Rivalry();
+        RiotAccount account = new RiotAccount("Hide", "KR1", "puuid0");
+        RivalryParticipant participant = new RivalryParticipant(account, rivalry, RivalSide.LEFT);
+
+        // when
+        rivalry.getParticipants().add(participant);
+        Rivalry found = rivalryRepository.save(rivalry);
+
+        // then
+        assertThat(found.getParticipants().size()).isEqualTo(1);
+    }
+
+}

--- a/api/src/test/java/com/glennsyj/rivals/api/rivalry/controller/RivalryControllerTest.java
+++ b/api/src/test/java/com/glennsyj/rivals/api/rivalry/controller/RivalryControllerTest.java
@@ -1,0 +1,78 @@
+package com.glennsyj.rivals.api.rivalry.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.glennsyj.rivals.api.rivalry.entity.RivalSide;
+import com.glennsyj.rivals.api.rivalry.model.RivalryCreationDto;
+import com.glennsyj.rivals.api.rivalry.model.RivalryParticipantDto;
+import com.glennsyj.rivals.api.rivalry.service.RivalryService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(RivalryController.class)
+@WithMockUser
+class RivalryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private RivalryService rivalryService;
+
+    @Test
+    @DisplayName("라이벌리 생성 요청이 성공하면 201 Created를 반환한다")
+    void createRivalry_Success() throws Exception {
+        // given
+        List<RivalryParticipantDto> participants = List.of(
+                new RivalryParticipantDto(1L, RivalSide.LEFT),
+                new RivalryParticipantDto(2L, RivalSide.RIGHT)
+        );
+        RivalryCreationDto creationDto = new RivalryCreationDto(participants);
+        Long rivalryId = 1L;
+
+        String content = new ObjectMapper().writeValueAsString(creationDto);
+        System.out.println(content);
+
+        when(rivalryService.createRivalryFrom(any(RivalryCreationDto.class)))
+                .thenReturn(rivalryId);
+
+        // when & then
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/rivalries")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(content)
+                        .with(csrf()))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", "/api/v1/rivalries/" + rivalryId))
+                .andExpect(jsonPath("$.rivalryId").value(rivalryId))
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("잘못된 형식의 요청이 오면 400 Bad Request를 반환한다")
+    void createRivalry_BadRequest() throws Exception {
+        // given
+        String invalidContent = "{\"participants\":[]}"; // 빈 participants 리스트를 포함한 JSON
+
+        // when & then
+        mockMvc.perform(MockMvcRequestBuilders.post("/api/v1/rivalries")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(invalidContent)
+                        .with(csrf()))
+                .andExpect(status().isBadRequest())
+                .andDo(print());
+    }
+}

--- a/api/src/test/java/com/glennsyj/rivals/api/rivalry/repository/RivalryRepositoryTest.java
+++ b/api/src/test/java/com/glennsyj/rivals/api/rivalry/repository/RivalryRepositoryTest.java
@@ -1,4 +1,4 @@
-package com.glennsyj.rivals.api.rival.repository;
+package com.glennsyj.rivals.api.rivalry.repository;
 
 import com.glennsyj.rivals.api.config.TestContainerConfig;
 import com.glennsyj.rivals.api.riot.entity.RiotAccount;

--- a/api/src/test/java/com/glennsyj/rivals/api/rivalry/repository/RivalryRepositoryTest.java
+++ b/api/src/test/java/com/glennsyj/rivals/api/rivalry/repository/RivalryRepositoryTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
@@ -41,7 +42,7 @@ public class RivalryRepositoryTest {
         RivalryParticipant participant = new RivalryParticipant(account, rivalry, RivalSide.LEFT);
 
         // when
-        rivalry.getParticipants().add(participant);
+        rivalry.addParticipant(participant);
         Rivalry found = rivalryRepository.save(rivalry);
 
         // then
@@ -62,14 +63,30 @@ public class RivalryRepositoryTest {
         RivalryParticipant participant4 = new RivalryParticipant(accountBothSide, rivalry, RivalSide.RIGHT);
 
         // when
-        rivalry.getParticipants().add(participant);
-        rivalry.getParticipants().add(participant2);
-        rivalry.getParticipants().add(participant3);
-        rivalry.getParticipants().add(participant4);
+        rivalry.addParticipant(participant);
+        rivalry.addParticipant(participant2);
+        rivalry.addParticipant(participant3);
+        rivalry.addParticipant(participant4);
         Rivalry found = rivalryRepository.save(rivalry);
 
         // then
         assertThat(found.getParticipants().size()).isEqualTo(4);
+    }
+
+    @Test
+    void 한쪽에_같은_계정이_중복_참여되면_오류가_난다() {
+
+        // given
+        Rivalry rivalry = new Rivalry();
+        RiotAccount account = new RiotAccount("Hide", "KR1", "puuid0");
+        RivalryParticipant participant = new RivalryParticipant(account, rivalry, RivalSide.LEFT);
+        RivalryParticipant participant2 = new RivalryParticipant(account, rivalry, RivalSide.LEFT);
+
+        // when * then
+        rivalry.addParticipant(participant);
+
+        assertThatThrownBy(() -> rivalry.addParticipant(participant2))
+                .isInstanceOf(IllegalArgumentException.class);
     }
 
 }

--- a/api/src/test/java/com/glennsyj/rivals/api/rivalry/repository/RivalryRepositoryTest.java
+++ b/api/src/test/java/com/glennsyj/rivals/api/rivalry/repository/RivalryRepositoryTest.java
@@ -48,4 +48,28 @@ public class RivalryRepositoryTest {
         assertThat(found.getParticipants().size()).isEqualTo(1);
     }
 
+    @Test
+    void 양측에_같은_계정이_하나_포함되어도_된다() {
+
+        // given
+        Rivalry rivalry = new Rivalry();
+        RiotAccount accountBothSide = new RiotAccount("Hide", "KR1", "puuid0");
+        RiotAccount accountLeftSide = new RiotAccount("Hide", "KR2", "puuid1");
+        RiotAccount accountRightSide = new RiotAccount("Hide", "KR3", "puuid2");
+        RivalryParticipant participant = new RivalryParticipant(accountBothSide, rivalry, RivalSide.LEFT);
+        RivalryParticipant participant2 = new RivalryParticipant(accountLeftSide, rivalry, RivalSide.RIGHT);
+        RivalryParticipant participant3 = new RivalryParticipant(accountRightSide, rivalry, RivalSide.LEFT);
+        RivalryParticipant participant4 = new RivalryParticipant(accountBothSide, rivalry, RivalSide.RIGHT);
+
+        // when
+        rivalry.getParticipants().add(participant);
+        rivalry.getParticipants().add(participant2);
+        rivalry.getParticipants().add(participant3);
+        rivalry.getParticipants().add(participant4);
+        Rivalry found = rivalryRepository.save(rivalry);
+
+        // then
+        assertThat(found.getParticipants().size()).isEqualTo(4);
+    }
+
 }

--- a/api/src/test/java/com/glennsyj/rivals/api/rivalry/service/RivalryServiceTest.java
+++ b/api/src/test/java/com/glennsyj/rivals/api/rivalry/service/RivalryServiceTest.java
@@ -98,12 +98,13 @@ class RivalryServiceTest {
 
         List<RivalryParticipantDto> participants = List.of(
                 new RivalryParticipantDto(account.getId(), RivalSide.LEFT),
-                new RivalryParticipantDto(account.getId(), RivalSide.LEFT)
+                new RivalryParticipantDto(account.getId(), RivalSide.LEFT),
+                new RivalryParticipantDto(account.getId(), RivalSide.RIGHT)
         );
         RivalryCreationDto creationDto = new RivalryCreationDto(participants);
 
         // Mock repository response
-        when(riotAccountRepository.findAllByIdIn(List.of(1L, 1L)))
+        when(riotAccountRepository.findAllByIdIn(List.of(1L, 1L, 1L)))
                 .thenReturn(List.of(account));
 
         // when & then

--- a/api/src/test/java/com/glennsyj/rivals/api/rivalry/service/RivalryServiceTest.java
+++ b/api/src/test/java/com/glennsyj/rivals/api/rivalry/service/RivalryServiceTest.java
@@ -1,0 +1,114 @@
+package com.glennsyj.rivals.api.rivalry.service;
+
+import com.glennsyj.rivals.api.config.EntityTestUtil;
+import com.glennsyj.rivals.api.riot.entity.RiotAccount;
+import com.glennsyj.rivals.api.riot.repository.RiotAccountRepository;
+import com.glennsyj.rivals.api.rivalry.entity.RivalSide;
+import com.glennsyj.rivals.api.rivalry.entity.Rivalry;
+import com.glennsyj.rivals.api.rivalry.model.RivalryCreationDto;
+import com.glennsyj.rivals.api.rivalry.model.RivalryParticipantDto;
+import com.glennsyj.rivals.api.rivalry.repository.RivalryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RivalryServiceTest {
+
+    @Mock
+    private RivalryRepository rivalryRepository;
+
+    @Mock
+    private RiotAccountRepository riotAccountRepository;
+
+    private RivalryService rivalryService;
+
+    @BeforeEach
+    void setUp() {
+        rivalryService = new RivalryService(rivalryRepository, riotAccountRepository);
+    }
+
+    @Test
+    @DisplayName("정상적인 DTO로 라이벌리 생성 시 성공하고 ID를 반환한다")
+    void createRivalrySuccess() {
+        // given
+        RiotAccount account1 = new RiotAccount("user1", "tag1", "puuid1");
+        RiotAccount account2 = new RiotAccount("user2", "tag2", "puuid2");
+        EntityTestUtil.setId(account1, 1L);
+        EntityTestUtil.setId(account2, 2L);
+
+        List<RivalryParticipantDto> participants = List.of(
+                new RivalryParticipantDto(account1.getId(), RivalSide.LEFT),
+                new RivalryParticipantDto(account2.getId(), RivalSide.RIGHT)
+        );
+        RivalryCreationDto creationDto = new RivalryCreationDto(participants);
+
+        // Mock repository responses
+        when(riotAccountRepository.findAllByIdIn(List.of(1L, 2L)))
+                .thenReturn(List.of(account1, account2));
+        when(rivalryRepository.save(any())).thenAnswer(invocation -> {
+            Rivalry rivalry = invocation.getArgument(0);
+            EntityTestUtil.setId(rivalry,1L);
+            return rivalry;
+        });
+
+        // when
+        Long rivalryId = rivalryService.createRivalryFrom(creationDto);
+
+        // then
+        assertThat(rivalryId).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 계정 ID로 라이벌리 생성 시 예외가 발생한다")
+    void createRivalryWithNonExistentAccount() {
+        // given
+        List<RivalryParticipantDto> participants = List.of(
+                new RivalryParticipantDto(999L, RivalSide.LEFT),
+                new RivalryParticipantDto(888L, RivalSide.RIGHT)
+        );
+        RivalryCreationDto creationDto = new RivalryCreationDto(participants);
+
+        // Mock repository response for non-existent accounts
+        when(riotAccountRepository.findAllByIdIn(List.of(999L, 888L)))
+                .thenReturn(List.of());
+
+        // when & then
+        assertThatThrownBy(() -> rivalryService.createRivalryFrom(creationDto))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Some of accounts not found");
+    }
+
+    @Test
+    @DisplayName("같은 진영에 중복된 계정으로 라이벌리 생성 시 예외가 발생한다")
+    void createRivalryWithDuplicateAccountOnSameSide() {
+        // given
+        RiotAccount account = new RiotAccount("user1", "tag1", "puuid1");
+        EntityTestUtil.setId(account, 1L);
+
+        List<RivalryParticipantDto> participants = List.of(
+                new RivalryParticipantDto(account.getId(), RivalSide.LEFT),
+                new RivalryParticipantDto(account.getId(), RivalSide.LEFT)
+        );
+        RivalryCreationDto creationDto = new RivalryCreationDto(participants);
+
+        // Mock repository response
+        when(riotAccountRepository.findAllByIdIn(List.of(1L, 1L)))
+                .thenReturn(List.of(account));
+
+        // when & then
+        assertThatThrownBy(() -> rivalryService.createRivalryFrom(creationDto))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Participant already exists on the same side.");
+    }
+}


### PR DESCRIPTION
# 라이벌리 생성 기능 구현

## 개요
라이벌리 생성 기능을 구현하여 사용자들이 서로를 라이벌로 등록하고 경쟁할 수 있는 기반을 마련합니다. 이는 TFT 게임에서 사용자들 간의 경쟁 요소를 추가하여 서비스의 재미를 높이는 것을 목적으로 합니다.

## 주요 변경사항

### 1. 라이벌리 도메인 구현
- `Rivalry` 엔티티 구현으로 라이벌 관계 정보 저장
- `RivalryParticipant` 엔티티를 통한 라이벌 참여자 관리
- `RivalSide` enum을 통한 LEFT/RIGHT 진영 구분

### 2. 라이벌리 생성 API 구현
- `RivalryController`를 통한 라이벌리 생성 엔드포인트 구현
- DTO 계층 구현
  - `RivalryCreationDto`: 라이벌리 생성 요청 데이터 검증
  - `RivalryParticipantDto`: 참여자 정보 매핑
  - `RivalryResultDto`: 생성 결과 응답

### 3. 비즈니스 로직 구현
- `RivalryService`를 통한 라이벌리 생성 로직 구현
  - RiotAccount 조회 및 검증
  - 라이벌리 생성 및 참여자 등록
- 유효성 검사 구현
  - 각 진영(LEFT/RIGHT)별 최소 1명 이상의 참여자 필수
  - 동일 진영 내 중복 참여자 방지

## API 명세

### POST /api/v1/rivalries
라이벌리를 생성합니다.

**Request Body**
```json
{
    "participants": [
        {
            "id": 1,
            "side": "LEFT"
        },
        {
            "id": 2,
            "side": "RIGHT"
        }
    ]
}
```

**Response**
- Status: 201 Created
- Location: /api/v1/rivalries/{rivalryId}
- Body: 
```json
{
    "rivalryId": 1
}
```

## 다음 단계

1. TFT 전적 조회 API 연동 확장
2. 라이벌리 통계 및 조회 API 구현
3. eventPublisher 기반 비동기 처리
4. 캐싱 전략 수립
5. Rate Limiting 구현

이 PR은 라이벌리 기능의 기초가 되는 생성 기능을 구현합니다. 후속 PR에서는 라이벌리 조회, 통계, 전적 검색 등의 기능이 구현될 예정입니다.
