### PR TITLE
라이벌리 상세 정보 조회 기능 구현

### DIFF
--- a/api/src/main/java/com/glennsyj/rivals/api/rivalry/controller/RivalryController.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/rivalry/controller/RivalryController.java
@@ -1,14 +1,13 @@
 package com.glennsyj.rivals.api.rivalry.controller;
 
 import com.glennsyj.rivals.api.rivalry.model.RivalryCreationDto;
+import com.glennsyj.rivals.api.rivalry.model.RivalryDetailDto;
 import com.glennsyj.rivals.api.rivalry.model.RivalryResultDto;
 import com.glennsyj.rivals.api.rivalry.service.RivalryService;
+import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
 
@@ -31,5 +30,16 @@ public class RivalryController {
         URI uri = URI.create("/api/v1/rivalries/" + rivalryId);
 
         return ResponseEntity.created(uri).body(response);
+    }
+
+    @GetMapping("/{rivalryId}")
+    public ResponseEntity<?> getRivalryById(@PathVariable Long rivalryId) {
+
+        try {
+            RivalryDetailDto response = rivalryService.findRivalryFrom(rivalryId);
+            return ResponseEntity.ok(response);
+        } catch (EntityNotFoundException e) {
+            return ResponseEntity.notFound().build();
+        }
     }
 }

--- a/api/src/main/java/com/glennsyj/rivals/api/rivalry/model/ParticipantStatDto.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/rivalry/model/ParticipantStatDto.java
@@ -1,0 +1,13 @@
+package com.glennsyj.rivals.api.rivalry.model;
+
+import com.glennsyj.rivals.api.tft.model.TftStatusDto;
+
+/*
+    추후 확장될 가능성 있음
+ */
+public record ParticipantStatDto(
+        Long id,
+        String fullName,
+        TftStatusDto statistics
+) {
+}

--- a/api/src/main/java/com/glennsyj/rivals/api/rivalry/model/RivalryDetailDto.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/rivalry/model/RivalryDetailDto.java
@@ -1,0 +1,12 @@
+package com.glennsyj.rivals.api.rivalry.model;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record RivalryDetailDto(
+        Long rivalryId,
+        List<ParticipantStatDto> leftStats,
+        List<ParticipantStatDto> rightStats,
+        LocalDateTime createdAt
+) {
+}

--- a/api/src/test/java/com/glennsyj/rivals/api/rivalry/controller/RivalryControllerTest.java
+++ b/api/src/test/java/com/glennsyj/rivals/api/rivalry/controller/RivalryControllerTest.java
@@ -3,8 +3,10 @@ package com.glennsyj.rivals.api.rivalry.controller;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.glennsyj.rivals.api.rivalry.entity.RivalSide;
 import com.glennsyj.rivals.api.rivalry.model.RivalryCreationDto;
+import com.glennsyj.rivals.api.rivalry.model.RivalryDetailDto;
 import com.glennsyj.rivals.api.rivalry.model.RivalryParticipantDto;
 import com.glennsyj.rivals.api.rivalry.service.RivalryService;
+import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,6 +17,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -62,7 +65,7 @@ class RivalryControllerTest {
     }
 
     @Test
-    @DisplayName("잘못된 형식의 요청이 오면 400 Bad Request를 반환한다")
+    @DisplayName("잘못된 형식의 라이벌리 생성 요청이 오면 400 Bad Request를 반환한다")
     void createRivalry_BadRequest() throws Exception {
         // given
         String invalidContent = "{\"participants\":[]}"; // 빈 participants 리스트를 포함한 JSON
@@ -73,6 +76,45 @@ class RivalryControllerTest {
                         .content(invalidContent)
                         .with(csrf()))
                 .andExpect(status().isBadRequest())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("존재하는 라이벌리 ID로 조회하면 200 OK와 상세 정보를 반환한다")
+    void getRivalryById_Success() throws Exception {
+        // given
+        Long rivalryId = 1L;
+        RivalryDetailDto detailDto = new RivalryDetailDto(
+                rivalryId,
+                List.of(),
+                List.of(),
+                LocalDateTime.now()
+        );
+
+        when(rivalryService.findRivalryFrom(rivalryId)).thenReturn(detailDto);
+
+        // when & then
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/rivalries/" + rivalryId)
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.rivalryId").value(rivalryId))
+                .andExpect(jsonPath("$.leftStats").isArray())
+                .andExpect(jsonPath("$.rightStats").isArray())
+                .andDo(print());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 라이벌리 ID로 조회하면 404 Not Found를 반환한다")
+    void getRivalryById_NotFound() throws Exception {
+        // given
+        Long nonExistentId = 999L;
+        when(rivalryService.findRivalryFrom(nonExistentId))
+                .thenThrow(new EntityNotFoundException());
+
+        // when & then
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/v1/rivalries/" + nonExistentId)
+                        .with(csrf()))
+                .andExpect(status().isNotFound())
                 .andDo(print());
     }
 }

--- a/api/src/test/java/com/glennsyj/rivals/api/rivalry/service/RivalryServiceTest.java
+++ b/api/src/test/java/com/glennsyj/rivals/api/rivalry/service/RivalryServiceTest.java
@@ -5,9 +5,16 @@ import com.glennsyj.rivals.api.riot.entity.RiotAccount;
 import com.glennsyj.rivals.api.riot.repository.RiotAccountRepository;
 import com.glennsyj.rivals.api.rivalry.entity.RivalSide;
 import com.glennsyj.rivals.api.rivalry.entity.Rivalry;
+import com.glennsyj.rivals.api.rivalry.entity.RivalryParticipant;
+import com.glennsyj.rivals.api.rivalry.model.ParticipantStatDto;
 import com.glennsyj.rivals.api.rivalry.model.RivalryCreationDto;
+import com.glennsyj.rivals.api.rivalry.model.RivalryDetailDto;
 import com.glennsyj.rivals.api.rivalry.model.RivalryParticipantDto;
 import com.glennsyj.rivals.api.rivalry.repository.RivalryRepository;
+import com.glennsyj.rivals.api.tft.entity.TftLeagueEntry;
+import com.glennsyj.rivals.api.tft.model.TftLeagueEntryResponse;
+import com.glennsyj.rivals.api.tft.repository.TftLeagueEntryRepository;
+import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,10 +24,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -31,6 +40,9 @@ class RivalryServiceTest {
 
     @Mock
     private RiotAccountRepository riotAccountRepository;
+
+    @Mock
+    private TftLeagueEntryRepository tftLeagueEntryRepository;
 
     @InjectMocks
     private RivalryService rivalryService;
@@ -108,5 +120,83 @@ class RivalryServiceTest {
         assertThatThrownBy(() -> rivalryService.createRivalryFrom(creationDto))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Participant already exists on the same side.");
+    }
+
+    @Test
+    @DisplayName("라이벌리 ID로 상세 정보를 조회한다")
+    void findRivalryFrom_Success() {
+        // given
+        // 1. 라이벌리와 참가자 설정
+        RiotAccount account1 = new RiotAccount("user1", "tag1", "puuid1");
+        RiotAccount account2 = new RiotAccount("user2", "tag2", "puuid2");
+        EntityTestUtil.setId(account1, 1L);
+        EntityTestUtil.setId(account2, 2L);
+
+        Rivalry rivalry = new Rivalry();
+        EntityTestUtil.setId(rivalry, 1L);
+
+        RivalryParticipant participant1 = new RivalryParticipant(account1, rivalry, RivalSide.LEFT);
+        RivalryParticipant participant2 = new RivalryParticipant(account2, rivalry, RivalSide.RIGHT);
+        rivalry.addParticipant(participant1);
+        rivalry.addParticipant(participant2);
+
+        // 2. TFT 상태 정보 설정
+        TftLeagueEntry entry1 = createMockTftEntry(account1, "DIAMOND", "I");
+        TftLeagueEntry entry2 = createMockTftEntry(account2, "PLATINUM", "II");
+
+        // 3. Mock 설정
+        when(rivalryRepository.findById(1L)).thenReturn(Optional.of(rivalry));
+        when(riotAccountRepository.findAllById(anyList())).thenReturn(List.of(account1, account2));
+        when(tftLeagueEntryRepository.findAllById(anyList())).thenReturn(List.of(entry1, entry2));
+
+        // when
+        RivalryDetailDto result = rivalryService.findRivalryFrom(1L);
+
+        // then
+        assertThat(result.rivalryId()).isEqualTo(1L);
+
+        // LEFT 팀 검증
+        assertThat(result.leftStats().size()).isEqualTo(1);
+        ParticipantStatDto leftParticipant = result.leftStats().get(0);
+        assertThat(leftParticipant.fullName()).isEqualTo("user1#tag1");
+        assertThat(leftParticipant.statistics().tier()).isEqualTo("DIAMOND");
+
+        // RIGHT 팀 검증
+        assertThat(result.rightStats().size()).isEqualTo(1);
+        ParticipantStatDto rightParticipant = result.rightStats().get(0);
+        assertThat(rightParticipant.fullName()).isEqualTo("user2#tag2");
+        assertThat(rightParticipant.statistics().tier()).isEqualTo("PLATINUM");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 라이벌리 ID로 조회시 예외가 발생한다")
+    void findRivalryFrom_NotFound() {
+        // given
+        when(rivalryRepository.findById(999L)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> rivalryService.findRivalryFrom(999L))
+                .isInstanceOf(EntityNotFoundException.class);
+    }
+
+    // 테스트용 TftLeagueEntry 생성 헬퍼 메서드
+    private TftLeagueEntry createMockTftEntry(RiotAccount account, String tier, String rank) {
+        TftLeagueEntryResponse response = new TftLeagueEntryResponse(
+                account.getPuuid(),
+                "league-id",
+                "summoner-id",
+                "RANKED_TFT",
+                tier,
+                rank,
+                100,
+                10,
+                5,
+                false,
+                false,
+                false,
+                false,
+                null
+        );
+        return new TftLeagueEntry(account, response);
     }
 }

--- a/api/src/test/java/com/glennsyj/rivals/api/rivalry/service/RivalryServiceTest.java
+++ b/api/src/test/java/com/glennsyj/rivals/api/rivalry/service/RivalryServiceTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -31,12 +32,8 @@ class RivalryServiceTest {
     @Mock
     private RiotAccountRepository riotAccountRepository;
 
+    @InjectMocks
     private RivalryService rivalryService;
-
-    @BeforeEach
-    void setUp() {
-        rivalryService = new RivalryService(rivalryRepository, riotAccountRepository);
-    }
 
     @Test
     @DisplayName("정상적인 DTO로 라이벌리 생성 시 성공하고 ID를 반환한다")


### PR DESCRIPTION
# 라이벌리 상세 정보 조회 기능 구현

## 개요
라이벌리의 상세 정보를 조회하는 기능을 구현합니다. 라이벌리에 참여한 사용자들의 정보와 TFT 상태를 LEFT/RIGHT 진영별로 구분하여 제공합니다.

## 주요 변경사항

### 1. 라이벌리 상세 조회 구현
- `RivalryService.findRivalryFrom` 메서드 구현
  - 라이벌리 기본 정보 조회
  - 참여자 정보 LEFT/RIGHT 진영별 분류
  - 각 참여자의 TFT 상태 정보 매핑

### 2. DTO 계층 구현
- `RivalryDetailDto`: 라이벌리 상세 정보 전달 객체
  - 라이벌리 ID
  - LEFT/RIGHT 진영별 참가자 목록
  - 생성 시간 정보
- `ParticipantStatDto`: 참가자 상태 정보 전달 객체
  - 참가자 ID와 게임 닉네임
  - TFT 상태 정보

### 3. 컨트롤러 구현
- `RivalryController.getRivalryById` 메서드 구현
  - 라이벌리 ID를 통한 상세 정보 조회
  - 존재하지 않는 라이벌리에 대한 예외 처리

## API 명세

### GET /api/v1/rivalries/{rivalryId}
라이벌리 상세 정보를 조회합니다.

**Response**
```json
{
    "rivalryId": 1,
    "leftStats": [
        {
            "participantId": 1,
            "fullName": "user1#KR1",
            "statistics": {
                "tier": "DIAMOND",
                "rank": "I",
                "leaguePoints": 75,
                "wins": 10,
                "losses": 5,
                "hotStreak": false
            }
        }
    ],
    "rightStats": [...],
    "createdAt": "2024-03-21T10:00:00"
}
```

## 테스트 구현
- `RivalryControllerTest` 구현
  - 라이벌리 조회 성공 케이스
  - 존재하지 않는 라이벌리 조회 케이스
- `RivalryServiceTest` 구현
  - 라이벌리 상세 정보 조회 로직 검증
  - 예외 처리 검증

## 다음 단계
1. 프론트엔드 초기화 및 구현
2. TFT 전적 조회 API 연동 확장
3. EventPublisher 기반 비동기 처리
4. 캐싱 전략 수립
5. Rate Limiting 구현

이 PR은 라이벌리의 상세 정보를 조회하는 기본적인 기능을 구현합니다. 이번 PR을 기반으로 승률 계산 등의 추가 기능이 구현될 예정입니다.
