### PR TITLE
TFT 매치 조회 성능 개선 및 모니터링 강화 #25

### DIFF
--- a/api/src/main/java/com/glennsyj/rivals/api/common/client/BaseRiotClient.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/common/client/BaseRiotClient.java
@@ -29,6 +29,7 @@ public abstract class BaseRiotClient {
     }
 
     protected <T> T handleApiCall(Mono<T> apiCall, String errorMessage) {
+        long startTime = System.currentTimeMillis();
         try {
             return apiCall
                     .retryWhen(Retry.backoff(MAX_RETRIES, INITIAL_BACKOFF)
@@ -45,6 +46,9 @@ public abstract class BaseRiotClient {
                 throw new IllegalStateException("Riot API 호출 횟수 제한 초과. " + retryAfter + "초 후에 다시 시도해주세요.", e);
             }
             throw new IllegalStateException("Riot API 호출 실패: " + e.getResponseBodyAsString(), e);
+        } finally {
+            long duration = System.currentTimeMillis() - startTime;
+            logger.info("Riot API call for '{}' completed in {}ms", this.getClass(), duration);
         }
     }
 

--- a/api/src/main/java/com/glennsyj/rivals/api/tft/TftApiClient.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/tft/TftApiClient.java
@@ -7,6 +7,7 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
 
 import java.util.List;
 
@@ -52,4 +53,11 @@ public class TftApiClient extends BaseRiotClient {
         );
     }
 
+    public Mono<TftMatchResponse> getMatchResponseFromMatchIdMono(String matchId) {
+        return riotAsiaWebClient.get()
+            .uri("/tft/match/v1/matches/{matchId}", matchId)
+            .accept(MediaType.APPLICATION_JSON)
+            .retrieve()
+            .bodyToMono(TftMatchResponse.class);
+    }
 }

--- a/api/src/main/resources/application-dev.yml
+++ b/api/src/main/resources/application-dev.yml
@@ -14,7 +14,7 @@ spring:
     show-sql: true
     properties:
       hibernate:
-        generate_statistics: false
+        generate_statistics: true
         jdbc:
           batch_size: 100 # 가장 많이 사용되는 값
           order_inserts: true


### PR DESCRIPTION
# TFT 매치 조회 성능 개선 및 모니터링 강화 #25

## 개요
TFT 매치 조회 시 발생하는 성능 병목 현상을 개선하고, API 호출 모니터링을 강화했습니다. Development API Key 환경에서 Riot API의 Rate Limit을 준수하면서도 효율적인 매치 데이터 조회가 가능하도록 비동기 처리 방식을 도입했습니다.

## 주요 변경사항

### 1. 어플리케이션 모니터링 강화
- `BaseRiotClient`에 API 호출 시간 측정 및 로깅 기능 추가
- Hibernate 통계 생성 활성화로 데이터베이스 성능 모니터링 개선
```yaml
spring:
  jpa:
    properties:
      hibernate:
        generate_statistics: true
```

### 2. TFT 매치 조회 성능 개선
- 비동기 매치 데이터 조회 구현
  - `TftApiClient`에 비동기 메소드 `getMatchResponseFromMatchIdMono` 추가
  - `Flux`와 `delayElements`를 활용한 Rate Limit 준수 (51ms 간격)
  - 트랜잭션 설정 최적화 (`readOnly` → 일반 트랜잭션)

### 3. K6 부하 테스트 개선
- 테스트 반복 횟수 제어 로직 추가
  - 정확히 4회 반복 후 테스트 종료 (Riot API 2분/100회 제한 준수)
  - `scenario.iterationInTest` 기반의 안정적인 테스트 사용자 순환
- 테스트 실행 시간 조정 (2m → 2m30s)

## 성능 개선 결과
Spring Actuator 메트릭 기준:
- Matches 조회: 총 14.86초 (4회 요청) -> 8.15초 (4회 요청)

`baseline-test.js` 기준:
- 여전히 총 1.5초 기준에는 부합하지 않으나, Production 환경이라면 충족 예정
- 현재 API 제한으로 20개를 1초 내에서 50m 간격으로 하나 씩 요청하므로, 요청 당 1초 절감 가능
- Production API Key 예상: 4.x초 (4회 요청) = 통과 가능

## 테스트
- k6 테스트를 통한 성능 검증 및 Spring Actutator를 통한 확인

## 관련 이슈
Fixes #25

이 PR은 TFT 매치 조회의 성능을 개선하고 모니터링을 강화하여, Riot API의 제한을 준수하면서도 효율적인 데이터 조회가 가능하도록 했습니다. 특히 비동기 처리 방식의 도입으로 매치 데이터 조회 시간을 최적화했습니다.