### PR TITLE
TftMatch 및 TfTMatchParticipant 인덱스 최적화

### DIFF
--- a/api/src/main/java/com/glennsyj/rivals/api/tft/entity/match/TftMatch.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/tft/entity/match/TftMatch.java
@@ -18,7 +18,8 @@ import java.util.Objects;
 @Entity
 @Table(name = "tft_matches",
         indexes = {
-                @Index(name = "idx_match_id", columnList = "matchId", unique = true)
+                @Index(name = "idx_match_id", columnList = "matchId", unique = true),
+                @Index(name = "idx_game_creation_id_desc", columnList = "gameCreation DESC, id")
         })
 public class TftMatch {
     @Id

--- a/api/src/main/java/com/glennsyj/rivals/api/tft/entity/match/TftMatchParticipant.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/tft/entity/match/TftMatchParticipant.java
@@ -12,7 +12,10 @@ import org.hibernate.proxy.HibernateProxy;
 import java.util.List;
 
 @Entity
-@Table(name = "tft_match_participants")
+@Table(name = "tft_match_participants",
+        indexes = {
+                @Index(name = "idx_match_puuid", columnList = "match_id, puuid")
+        })
 public class TftMatchParticipant {
     @Id
     @Tsid

--- a/api/src/main/resources/application-dev.yml
+++ b/api/src/main/resources/application-dev.yml
@@ -10,7 +10,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:

--- a/api/src/main/resources/application-dev.yml
+++ b/api/src/main/resources/application-dev.yml
@@ -49,5 +49,6 @@ logging:
   level:
     com.glennsyj.rivals: DEBUG
     org.hibernate.SQL: DEBUG
+    org.hibernate.type: TRACE
     org.hibernate.stat: DEBUG
     org.hibernate.type.descriptor.sql: TRACE

--- a/infra/sql/ddl-dev.sql
+++ b/infra/sql/ddl-dev.sql
@@ -1,0 +1,223 @@
+/*M!999999\- enable the sandbox mode */ 
+-- MariaDB dump 10.19-11.7.2-MariaDB, for Win64 (AMD64)
+--
+-- Host: localhost    Database: mydatabase
+-- ------------------------------------------------------
+-- Server version	11.7.2-MariaDB-ubu2404
+
+/*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
+/*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
+/*!40101 SET @OLD_COLLATION_CONNECTION=@@COLLATION_CONNECTION */;
+/*!40101 SET NAMES utf8mb4 */;
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*M!100616 SET @OLD_NOTE_VERBOSITY=@@NOTE_VERBOSITY, NOTE_VERBOSITY=0 */;
+
+--
+-- Table structure for table `riot_accounts`
+--
+
+DROP TABLE IF EXISTS `riot_accounts`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `riot_accounts` (
+  `created_at` datetime(6) NOT NULL,
+  `id` bigint(20) NOT NULL,
+  `updated_at` datetime(6) DEFAULT NULL,
+  `game_name` varchar(255) NOT NULL,
+  `puuid` varchar(255) NOT NULL,
+  `tag_line` varchar(255) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `uk_riot_accounts_puuid` (`puuid`),
+  KEY `idx_riot_accounts_game_name_tag_line` (`game_name`,`tag_line`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `rivalries`
+--
+
+DROP TABLE IF EXISTS `rivalries`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `rivalries` (
+  `created_at` datetime(6) NOT NULL,
+  `id` bigint(20) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `rivalry_participants`
+--
+
+DROP TABLE IF EXISTS `rivalry_participants`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `rivalry_participants` (
+  `created_at` datetime(6) NOT NULL,
+  `id` bigint(20) NOT NULL,
+  `riot_account_id` bigint(20) NOT NULL,
+  `rivalry_id` bigint(20) NOT NULL,
+  `side` enum('LEFT','RIGHT') DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `FK1uhhtqqgqjhxbqg150l703ouj` (`riot_account_id`),
+  KEY `FK4iwdi6a4k5v05ywu83gps6bod` (`rivalry_id`),
+  CONSTRAINT `FK1uhhtqqgqjhxbqg150l703ouj` FOREIGN KEY (`riot_account_id`) REFERENCES `riot_accounts` (`id`),
+  CONSTRAINT `FK4iwdi6a4k5v05ywu83gps6bod` FOREIGN KEY (`rivalry_id`) REFERENCES `rivalries` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `tft_badge_progress`
+--
+
+DROP TABLE IF EXISTS `tft_badge_progress`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `tft_badge_progress` (
+  `achievement_count` int(11) NOT NULL,
+  `is_active` bit(1) NOT NULL,
+  `id` bigint(20) NOT NULL,
+  `last_updated_at` datetime(6) NOT NULL,
+  `riot_account_id` bigint(20) NOT NULL,
+  `badge_type` enum('DAMAGE_DEALER','EXECUTOR','LUXURY','MVP','STEADY') NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `UK6loylpgp0cbuxglhm2td81dp3` (`riot_account_id`,`badge_type`),
+  CONSTRAINT `FKg9i1ihexxddfgcvwku20loktr` FOREIGN KEY (`riot_account_id`) REFERENCES `riot_accounts` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `tft_league_entries`
+--
+
+DROP TABLE IF EXISTS `tft_league_entries`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `tft_league_entries` (
+  `fresh_blood` bit(1) DEFAULT NULL,
+  `hot_streak` bit(1) DEFAULT NULL,
+  `inactive` bit(1) NOT NULL,
+  `league_points` int(11) DEFAULT NULL,
+  `losses` int(11) NOT NULL,
+  `mini_series_losses` int(11) DEFAULT NULL,
+  `mini_series_target` int(11) DEFAULT NULL,
+  `mini_series_wins` int(11) DEFAULT NULL,
+  `veteran` bit(1) NOT NULL,
+  `wins` int(11) NOT NULL,
+  `account_id` bigint(20) NOT NULL,
+  `id` bigint(20) NOT NULL,
+  `updated_at` datetime(6) DEFAULT NULL,
+  `version` bigint(20) DEFAULT NULL,
+  `league_id` varchar(255) NOT NULL,
+  `mini_series_progress` varchar(255) DEFAULT NULL,
+  `puuid` varchar(255) NOT NULL,
+  `summoner_id` varchar(255) DEFAULT NULL,
+  `queue_type` enum('RANKED_TFT','RANKED_TFT_DOUBLE_UP','RANKED_TFT_TURBO') NOT NULL,
+  `rank` enum('I','II','III','IV') DEFAULT NULL,
+  `tier` enum('BRONZE','CHALLENGER','DIAMOND','EMERALD','GOLD','GRANDMASTER','IRON','MASTER','PLATINUM','SILVER') DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `FKrtjyh84cu4s69dvangklocoy2` (`account_id`),
+  CONSTRAINT `FKrtjyh84cu4s69dvangklocoy2` FOREIGN KEY (`account_id`) REFERENCES `riot_accounts` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `tft_match_achievements`
+--
+
+DROP TABLE IF EXISTS `tft_match_achievements`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `tft_match_achievements` (
+  `value` int(11) NOT NULL,
+  `id` bigint(20) NOT NULL,
+  `match_id` bigint(20) NOT NULL,
+  `participant_id` bigint(20) NOT NULL,
+  `type` enum('FIRST_PLACE','MOST_DAMAGE_DEALT','MOST_ELIMINATIONS','MOST_EXPENSIVE_SQUAD','TOP_FOUR') NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `FKi83tm8rufuskebq52ittk3wsd` (`participant_id`),
+  KEY `FKn5h3x6yu13ovs3rffq8c3e6e1` (`match_id`),
+  CONSTRAINT `FKi83tm8rufuskebq52ittk3wsd` FOREIGN KEY (`participant_id`) REFERENCES `tft_match_participants` (`id`),
+  CONSTRAINT `FKn5h3x6yu13ovs3rffq8c3e6e1` FOREIGN KEY (`match_id`) REFERENCES `tft_matches` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `tft_match_participants`
+--
+
+DROP TABLE IF EXISTS `tft_match_participants`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `tft_match_participants` (
+  `gold_left` int(11) NOT NULL,
+  `last_round` int(11) NOT NULL,
+  `level` int(11) NOT NULL,
+  `missions_player_score2` int(11) NOT NULL,
+  `placement` int(11) NOT NULL,
+  `players_eliminated` int(11) NOT NULL,
+  `time_eliminated` double NOT NULL,
+  `total_damage_to_players` int(11) NOT NULL,
+  `win` bit(1) NOT NULL,
+  `id` bigint(20) NOT NULL,
+  `match_id` bigint(20) NOT NULL,
+  `puuid` varchar(255) NOT NULL,
+  `riot_id_game_name` varchar(255) NOT NULL,
+  `riot_id_tagline` varchar(255) NOT NULL,
+  `companion` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL CHECK (json_valid(`companion`)),
+  `traits` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL CHECK (json_valid(`traits`)),
+  `units` longtext CHARACTER SET utf8mb4 COLLATE utf8mb4_bin DEFAULT NULL CHECK (json_valid(`units`)),
+  PRIMARY KEY (`id`),
+  KEY `FKjhu1pr203iykpu9hel74vsdwd` (`match_id`),
+  CONSTRAINT `FKjhu1pr203iykpu9hel74vsdwd` FOREIGN KEY (`match_id`) REFERENCES `tft_matches` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `tft_matches`
+--
+
+DROP TABLE IF EXISTS `tft_matches`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8mb4 */;
+CREATE TABLE `tft_matches` (
+  `game_length` double NOT NULL,
+  `map_id` int(11) NOT NULL,
+  `queue_id` int(11) NOT NULL,
+  `tft_set_number` int(11) NOT NULL,
+  `created_at` datetime(6) DEFAULT NULL,
+  `game_creation` bigint(20) NOT NULL,
+  `game_date_time` bigint(20) NOT NULL,
+  `game_id` bigint(20) NOT NULL,
+  `id` bigint(20) NOT NULL,
+  `data_version` varchar(255) NOT NULL,
+  `end_of_game_result` varchar(255) NOT NULL,
+  `game_variation` varchar(255) DEFAULT NULL,
+  `game_version` varchar(255) NOT NULL,
+  `match_id` varchar(255) NOT NULL,
+  `tft_game_type` varchar(255) NOT NULL,
+  `tft_set_core_name` varchar(255) NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `idx_match_id` (`match_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_uca1400_ai_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Dumping routines for database 'mydatabase'
+--
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
+/*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;
+/*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
+/*M!100616 SET NOTE_VERBOSITY=@OLD_NOTE_VERBOSITY */;
+
+-- Dump completed on 2025-07-06 23:35:39

--- a/infra/sql/dummy-data.sql
+++ b/infra/sql/dummy-data.sql
@@ -787,7 +787,124 @@ FROM
     numbers_table n
 JOIN tft_match_ids tmi ON tmi.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM tft_match_ids))
 JOIN tft_participant_ids tpi ON tpi.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM tft_participant_ids))
-WHERE n.rn <= 50000;
+WHERE n.rn BETWEEN 1 AND 5000;
+
+INSERT INTO tft_match_achievements (id, value, match_id, participant_id, type)
+SELECT 
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 6) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
+    FLOOR(RAND() * 1000), -- Random achievement value
+    tmi.id, -- Link to tft_matches
+    tpi.id, -- Link to tft_match_participants
+    ELT(1 + FLOOR(RAND() * 5), 'FIRST_PLACE', 'MOST_DAMAGE_DEALT', 'MOST_ELIMINATIONS', 'MOST_EXPENSIVE_SQUAD', 'TOP_FOUR')
+FROM 
+    numbers_table n
+JOIN tft_match_ids tmi ON tmi.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM tft_match_ids))
+JOIN tft_participant_ids tpi ON tpi.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM tft_participant_ids))
+WHERE n.rn BETWEEN 5001 AND 10000;
+
+INSERT INTO tft_match_achievements (id, value, match_id, participant_id, type)
+SELECT 
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 6) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
+    FLOOR(RAND() * 1000), -- Random achievement value
+    tmi.id, -- Link to tft_matches
+    tpi.id, -- Link to tft_match_participants
+    ELT(1 + FLOOR(RAND() * 5), 'FIRST_PLACE', 'MOST_DAMAGE_DEALT', 'MOST_ELIMINATIONS', 'MOST_EXPENSIVE_SQUAD', 'TOP_FOUR')
+FROM 
+    numbers_table n
+JOIN tft_match_ids tmi ON tmi.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM tft_match_ids))
+JOIN tft_participant_ids tpi ON tpi.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM tft_participant_ids))
+WHERE n.rn BETWEEN 10001 AND 15000;
+
+INSERT INTO tft_match_achievements (id, value, match_id, participant_id, type)
+SELECT 
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 6) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
+    FLOOR(RAND() * 1000), -- Random achievement value
+    tmi.id, -- Link to tft_matches
+    tpi.id, -- Link to tft_match_participants
+    ELT(1 + FLOOR(RAND() * 5), 'FIRST_PLACE', 'MOST_DAMAGE_DEALT', 'MOST_ELIMINATIONS', 'MOST_EXPENSIVE_SQUAD', 'TOP_FOUR')
+FROM 
+    numbers_table n
+JOIN tft_match_ids tmi ON tmi.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM tft_match_ids))
+JOIN tft_participant_ids tpi ON tpi.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM tft_participant_ids))
+WHERE n.rn BETWEEN 15001 AND 20000;
+
+INSERT INTO tft_match_achievements (id, value, match_id, participant_id, type)
+SELECT 
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 6) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
+    FLOOR(RAND() * 1000), -- Random achievement value
+    tmi.id, -- Link to tft_matches
+    tpi.id, -- Link to tft_match_participants
+    ELT(1 + FLOOR(RAND() * 5), 'FIRST_PLACE', 'MOST_DAMAGE_DEALT', 'MOST_ELIMINATIONS', 'MOST_EXPENSIVE_SQUAD', 'TOP_FOUR')
+FROM 
+    numbers_table n
+JOIN tft_match_ids tmi ON tmi.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM tft_match_ids))
+JOIN tft_participant_ids tpi ON tpi.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM tft_participant_ids))
+WHERE n.rn BETWEEN 20001 AND 25000;
+
+INSERT INTO tft_match_achievements (id, value, match_id, participant_id, type)
+SELECT 
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 6) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
+    FLOOR(RAND() * 1000), -- Random achievement value
+    tmi.id, -- Link to tft_matches
+    tpi.id, -- Link to tft_match_participants
+    ELT(1 + FLOOR(RAND() * 5), 'FIRST_PLACE', 'MOST_DAMAGE_DEALT', 'MOST_ELIMINATIONS', 'MOST_EXPENSIVE_SQUAD', 'TOP_FOUR')
+FROM 
+    numbers_table n
+JOIN tft_match_ids tmi ON tmi.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM tft_match_ids))
+JOIN tft_participant_ids tpi ON tpi.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM tft_participant_ids))
+WHERE n.rn BETWEEN 25001 AND 30000;
+
+INSERT INTO tft_match_achievements (id, value, match_id, participant_id, type)
+SELECT 
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 6) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
+    FLOOR(RAND() * 1000), -- Random achievement value
+    tmi.id, -- Link to tft_matches
+    tpi.id, -- Link to tft_match_participants
+    ELT(1 + FLOOR(RAND() * 5), 'FIRST_PLACE', 'MOST_DAMAGE_DEALT', 'MOST_ELIMINATIONS', 'MOST_EXPENSIVE_SQUAD', 'TOP_FOUR')
+FROM 
+    numbers_table n
+JOIN tft_match_ids tmi ON tmi.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM tft_match_ids))
+JOIN tft_participant_ids tpi ON tpi.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM tft_participant_ids))
+WHERE n.rn BETWEEN 30001 AND 35000;
+
+INSERT INTO tft_match_achievements (id, value, match_id, participant_id, type)
+SELECT 
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 6) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
+    FLOOR(RAND() * 1000), -- Random achievement value
+    tmi.id, -- Link to tft_matches
+    tpi.id, -- Link to tft_match_participants
+    ELT(1 + FLOOR(RAND() * 5), 'FIRST_PLACE', 'MOST_DAMAGE_DEALT', 'MOST_ELIMINATIONS', 'MOST_EXPENSIVE_SQUAD', 'TOP_FOUR')
+FROM 
+    numbers_table n
+JOIN tft_match_ids tmi ON tmi.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM tft_match_ids))
+JOIN tft_participant_ids tpi ON tpi.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM tft_participant_ids))
+WHERE n.rn BETWEEN 35001 AND 40000;
+
+INSERT INTO tft_match_achievements (id, value, match_id, participant_id, type)
+SELECT 
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 6) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
+    FLOOR(RAND() * 1000), -- Random achievement value
+    tmi.id, -- Link to tft_matches
+    tpi.id, -- Link to tft_match_participants
+    ELT(1 + FLOOR(RAND() * 5), 'FIRST_PLACE', 'MOST_DAMAGE_DEALT', 'MOST_ELIMINATIONS', 'MOST_EXPENSIVE_SQUAD', 'TOP_FOUR')
+FROM 
+    numbers_table n
+JOIN tft_match_ids tmi ON tmi.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM tft_match_ids))
+JOIN tft_participant_ids tpi ON tpi.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM tft_participant_ids))
+WHERE n.rn BETWEEN 40001 AND 45000;
+
+INSERT INTO tft_match_achievements (id, value, match_id, participant_id, type)
+SELECT 
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 6) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
+    FLOOR(RAND() * 1000), -- Random achievement value
+    tmi.id, -- Link to tft_matches
+    tpi.id, -- Link to tft_match_participants
+    ELT(1 + FLOOR(RAND() * 5), 'FIRST_PLACE', 'MOST_DAMAGE_DEALT', 'MOST_ELIMINATIONS', 'MOST_EXPENSIVE_SQUAD', 'TOP_FOUR')
+FROM 
+    numbers_table n
+JOIN tft_match_ids tmi ON tmi.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM tft_match_ids))
+JOIN tft_participant_ids tpi ON tpi.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM tft_participant_ids))
+WHERE n.rn BETWEEN 45001 AND 50000;
 
 -- Generate tft_league_entries (3000 records, 3 per account for different queue types)
 INSERT INTO tft_league_entries (

--- a/infra/sql/dummy-data.sql
+++ b/infra/sql/dummy-data.sql
@@ -4,25 +4,24 @@ SET UNIQUE_CHECKS=0;
 SET SQL_MODE='NO_AUTO_VALUE_ON_ZERO';
 
 -- Drop existing functions if they exist
-DROP FUNCTION IF EXISTS generate_tsid;
 DROP FUNCTION IF EXISTS rand_datetime;
 
--- Function to generate TSID
-DELIMITER //
-CREATE FUNCTION generate_tsid()
-RETURNS BIGINT
-BEGIN
-    -- Get current timestamp in milliseconds (Unix epoch)
-    SET @now = UNIX_TIMESTAMP(NOW(3)) * 1000;
-    
-    -- Generate random number for the lower bits (0-1023)
-    SET @random = FLOOR(RAND() * 1024);
-    
-    -- Combine timestamp and random number
-    -- Shift timestamp left by 10 bits and combine with random number
-    RETURN (@now << 10) | @random;
-END //
-DELIMITER ;
+-- Drop temporary tables if they exist
+DROP TEMPORARY TABLE IF EXISTS account_ids;
+DROP TEMPORARY TABLE IF EXISTS rivalry_ids;
+DROP TEMPORARY TABLE IF EXISTS tft_match_ids;
+DROP TEMPORARY TABLE IF EXISTS tft_participant_ids;
+DROP TEMPORARY TABLE IF EXISTS numbers_table;
+
+-- Truncate existing data from tables
+TRUNCATE TABLE tft_league_entries;
+TRUNCATE TABLE tft_badge_progress;
+TRUNCATE TABLE tft_match_achievements;
+TRUNCATE TABLE tft_match_participants;
+TRUNCATE TABLE tft_matches;
+TRUNCATE TABLE rivalry_participants;
+TRUNCATE TABLE rivalries;
+TRUNCATE TABLE riot_accounts;
 
 -- Function to generate random datetime between two dates
 DELIMITER //
@@ -39,85 +38,56 @@ BEGIN
 END //
 DELIMITER ;
 
+-- Create a temporary numbers table for consistent row generation
+CREATE TEMPORARY TABLE numbers_table (
+    rn INT PRIMARY KEY
+);
+
+INSERT INTO numbers_table (rn)
+SELECT (t1.n + t2.n * 10 + t3.n * 100 + t4.n * 1000 + t5.n * 10000 + 1) AS rn -- +1 for 1-indexed
+FROM 
+    (SELECT 0 AS n UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4 UNION ALL SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9) AS t1
+CROSS JOIN
+    (SELECT 0 AS n UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4 UNION ALL SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9) AS t2
+CROSS JOIN
+    (SELECT 0 AS n UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4 UNION ALL SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9) AS t3
+CROSS JOIN
+    (SELECT 0 AS n UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4 UNION ALL SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9) AS t4
+CROSS JOIN
+    (SELECT 0 AS n UNION ALL SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4 UNION ALL SELECT 5 UNION ALL SELECT 6 UNION ALL SELECT 7 UNION ALL SELECT 8 UNION ALL SELECT 9) AS t5
+LIMIT 80000; -- Max records needed
+
 -- Generate riot_accounts (1000 records)
 INSERT INTO riot_accounts (id, created_at, updated_at, game_name, puuid, tag_line)
 SELECT 
-    generate_tsid(), -- TSID instead of sequential number
-    created_dt,
-    updated_dt,
-    CONCAT('Player', LPAD(rn, 4, '0')),
-    CONCAT('PUUID', LPAD(rn, 4, '0'), REPEAT(MD5(RAND()), 2)),
-    CONCAT('TAG', LPAD(rn, 4, '0'))
-FROM (
-    SELECT 
-        @row := @row + 1 as rn,
-        DATE_SUB(CURRENT_TIMESTAMP, INTERVAL FLOOR(RAND() * 365) DAY) as created_dt,
-        DATE_SUB(CURRENT_TIMESTAMP, INTERVAL FLOOR(RAND() * 30) DAY) as updated_dt
-    FROM (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t1,
-         (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t2,
-         (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t3,
-         (SELECT @row:=0) r
-    LIMIT 1000
-) numbers;
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 0) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
+    DATE_SUB(CURRENT_TIMESTAMP, INTERVAL FLOOR(RAND() * 365) DAY),
+    DATE_SUB(CURRENT_TIMESTAMP, INTERVAL FLOOR(RAND() * 30) DAY),
+    CONCAT('Player', LPAD(n.rn, 4, '0')),
+    CONCAT('PUUID', LPAD(n.rn, 4, '0'), REPEAT(MD5(RAND()), 2)),
+    CONCAT('TAG', LPAD(n.rn, 4, '0'))
+FROM 
+    numbers_table n
+WHERE n.rn <= 1000;
 
 -- Store generated IDs for reference
-CREATE TEMPORARY TABLE account_ids
+CREATE TEMPORARY TABLE account_ids AS
 SELECT id, ROW_NUMBER() OVER () as rn
 FROM riot_accounts;
 
 -- Generate rivalries (500 records)
 INSERT INTO rivalries (id, created_at)
 SELECT 
-    generate_tsid(),
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 1) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
     DATE_SUB(CURRENT_TIMESTAMP, INTERVAL FLOOR(RAND() * 365) DAY)
-FROM (
-    SELECT @row := @row + 1 as rn
-    FROM (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t1,
-         (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t2,
-         (SELECT @row:=0) r
-    LIMIT 500
-) numbers;
+FROM 
+    numbers_table n
+WHERE n.rn <= 500;
 
 -- Store generated rivalry IDs for reference
-CREATE TEMPORARY TABLE rivalry_ids
-SELECT id, ROW_NUMBER() OVER () as rn
+CREATE TEMPORARY TABLE rivalry_ids AS
+SELECT id, created_at, ROW_NUMBER() OVER () as rn
 FROM rivalries;
-
--- Generate rivalry_participants (2000 records, 4 per rivalry)
-INSERT INTO rivalry_participants (id, created_at, riot_account_id, rivalry_id, side)
-SELECT 
-    generate_tsid(),
-    r.created_at,
-    1 + FLOOR(RAND() * 1000), -- Random riot_account_id between 1 and 1000
-    1 + FLOOR((n-1)/4), -- Distribute 4 participants per rivalry
-    CASE WHEN (n % 4) < 2 THEN 'LEFT' ELSE 'RIGHT' END -- Alternate between LEFT and RIGHT
-FROM (
-    SELECT @row := @row + 1 as n
-    FROM (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t1,
-         (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t2,
-         (select 0 union all select 1 union all select 2 union all select 3 union all select 4) t3,
-         (SELECT @row:=0) r
-    LIMIT 2000
-) numbers
-JOIN rivalries r ON r.id = 1 + FLOOR((numbers.n-1)/4);
-
--- Generate tft_badge_progress (5000 records, 5 per account)
-INSERT INTO tft_badge_progress (id, achievement_count, is_active, last_updated_at, riot_account_id, badge_type)
-SELECT 
-    generate_tsid(),
-    FLOOR(RAND() * 100), -- Random achievement count between 0 and 99
-    1, -- All active
-    DATE_SUB(CURRENT_TIMESTAMP, INTERVAL FLOOR(RAND() * 30) DAY),
-    1 + FLOOR((n-1)/5), -- Distribute 5 badges per account
-    ELT(1 + (n-1) % 5, 'DAMAGE_DEALER', 'EXECUTOR', 'LUXURY', 'MVP', 'STEADY') -- Rotate through badge types
-FROM (
-    SELECT @row := @row + 1 as n
-    FROM (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t1,
-         (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t2,
-         (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t3,
-         (SELECT @row:=0) r
-    LIMIT 5000
-) numbers;
 
 -- Generate tft_matches (10000 records)
 INSERT INTO tft_matches (
@@ -127,30 +97,29 @@ INSERT INTO tft_matches (
     match_id, tft_game_type, tft_set_core_name
 )
 SELECT 
-    generate_tsid(),
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 2) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
     1200 + RAND() * 600, -- Game length between 1200 and 1800 seconds
     1,
     1100, -- Ranked queue_id
     10, -- Set 10
-    DATE_SUB(CURRENT_TIMESTAMP, INTERVAL FLOOR(RAND() * 30) DAY),
     UNIX_TIMESTAMP(DATE_SUB(CURRENT_TIMESTAMP, INTERVAL FLOOR(RAND() * 30) DAY)) * 1000,
     UNIX_TIMESTAMP(DATE_SUB(CURRENT_TIMESTAMP, INTERVAL FLOOR(RAND() * 30) DAY)) * 1000,
-    n + 1000000, -- Unique game_id
+    UNIX_TIMESTAMP(DATE_SUB(CURRENT_TIMESTAMP, INTERVAL FLOOR(RAND() * 30) DAY)) * 1000,
+    n.rn + 1000000, -- Unique game_id
     '3',
     'FINISHED',
     '13.24.1',
-    CONCAT('KR_', n + 1000000),
+    CONCAT('KR_', n.rn + 1000000),
     'RANKED_TFT',
     'TFT_SET10'
-FROM (
-    SELECT @row := @row + 1 as n
-    FROM (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t1,
-         (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t2,
-         (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t3,
-         (select 0 union all select 1) t4,
-         (SELECT @row:=0) r
-    LIMIT 10000
-) numbers;
+FROM 
+    numbers_table n
+WHERE n.rn <= 10000;
+
+-- Store generated tft_match IDs for reference
+CREATE TEMPORARY TABLE tft_match_ids AS
+SELECT id, ROW_NUMBER() OVER () as rn
+FROM tft_matches;
 
 -- Generate tft_match_participants (80000 records, 8 per match)
 INSERT INTO tft_match_participants (
@@ -160,58 +129,665 @@ INSERT INTO tft_match_participants (
     companion, traits, units
 )
 SELECT 
-    generate_tsid(),
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 3) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
     FLOOR(RAND() * 100), -- Random gold_left
     FLOOR(20 + RAND() * 20), -- Random last_round between 20 and 39
     FLOOR(5 + RAND() * 4), -- Random level between 5 and 8
     FLOOR(RAND() * 1000), -- Random mission score
-    1 + ((n-1) % 8), -- Placement 1-8 for each match
+    1 + ((n.rn-1) % 8), -- Placement 1-8 for each match
     FLOOR(RAND() * 3), -- Random players eliminated
     FLOOR(1000 + RAND() * 1000), -- Random time eliminated
     FLOOR(1000 + RAND() * 5000), -- Random damage dealt
-    IF(((n-1) % 8) = 0, 1, 0), -- First player in each match wins
-    1 + FLOOR((n-1)/8), -- Distribute 8 participants per match
+    IF(((n.rn-1) % 8) = 0, 1, 0), -- First player in each match wins
+    tmi.id, -- Link to tft_matches
     ra.puuid,
     ra.game_name,
     ra.tag_line,
     '{"content_ID": "1", "skin_ID": 1}', -- Simple companion JSON
     '[{"name":"Set10_Breakout","num_units":2,"style":1,"tier_current":1}]', -- Simple traits JSON
     '[{"character_id":"TFT10_Ahri","items":[1,2,3],"name":"Ahri","rarity":4,"tier":2}]' -- Simple units JSON
-FROM (
-    SELECT @row := @row + 1 as n
-    FROM (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t1,
-         (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t2,
-         (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t3,
-         (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t4,
-         (SELECT @row:=0) r
-    LIMIT 80000
-) numbers
-JOIN (
-    SELECT id % 1000 + 1 as random_id, puuid, game_name, tag_line
-    FROM (
-        SELECT @raid := @raid + 1 as id, puuid, game_name, tag_line
-        FROM riot_accounts,
-        (SELECT @raid:=0) r
-    ) t
-) ra ON ra.random_id = 1 + (numbers.n % 1000);
+FROM 
+    numbers_table n
+JOIN tft_match_ids tmi ON tmi.rn = CEIL(n.rn / 8)
+JOIN account_ids ai ON ai.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM account_ids))
+JOIN riot_accounts ra ON ra.id = ai.id
+WHERE n.rn BETWEEN 1 AND 4000;
+
+INSERT INTO tft_match_participants (
+    id, gold_left, last_round, level, missions_player_score2,
+    placement, players_eliminated, time_eliminated, total_damage_to_players,
+    win, match_id, puuid, riot_id_game_name, riot_id_tagline,
+    companion, traits, units
+)
+SELECT 
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 3) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
+    FLOOR(RAND() * 100), 
+    FLOOR(20 + RAND() * 20),
+    FLOOR(5 + RAND() * 4),
+    FLOOR(RAND() * 1000),
+    1 + ((n.rn-1) % 8),
+    FLOOR(RAND() * 3),
+    FLOOR(1000 + RAND() * 1000),
+    FLOOR(1000 + RAND() * 5000),
+    IF(((n.rn-1) % 8) = 0, 1, 0),
+    tmi.id,
+    ra.puuid,
+    ra.game_name,
+    ra.tag_line,
+    '{"content_ID": "1", "skin_ID": 1}',
+    '[{"name":"Set10_Breakout","num_units":2,"style":1,"tier_current":1}]',
+    '[{"character_id":"TFT10_Ahri","items":[1,2,3],"name":"Ahri","rarity":4,"tier":2}]'
+FROM 
+    numbers_table n
+JOIN tft_match_ids tmi ON tmi.rn = CEIL(n.rn / 8)
+JOIN account_ids ai ON ai.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM account_ids))
+JOIN riot_accounts ra ON ra.id = ai.id
+WHERE n.rn BETWEEN 4001 AND 8000;
+
+INSERT INTO tft_match_participants (
+    id, gold_left, last_round, level, missions_player_score2,
+    placement, players_eliminated, time_eliminated, total_damage_to_players,
+    win, match_id, puuid, riot_id_game_name, riot_id_tagline,
+    companion, traits, units
+)
+SELECT 
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 3) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
+    FLOOR(RAND() * 100), 
+    FLOOR(20 + RAND() * 20),
+    FLOOR(5 + RAND() * 4),
+    FLOOR(RAND() * 1000),
+    1 + ((n.rn-1) % 8),
+    FLOOR(RAND() * 3),
+    FLOOR(1000 + RAND() * 1000),
+    FLOOR(1000 + RAND() * 5000),
+    IF(((n.rn-1) % 8) = 0, 1, 0),
+    tmi.id,
+    ra.puuid,
+    ra.game_name,
+    ra.tag_line,
+    '{"content_ID": "1", "skin_ID": 1}',
+    '[{"name":"Set10_Breakout","num_units":2,"style":1,"tier_current":1}]',
+    '[{"character_id":"TFT10_Ahri","items":[1,2,3],"name":"Ahri","rarity":4,"tier":2}]'
+FROM 
+    numbers_table n
+JOIN tft_match_ids tmi ON tmi.rn = CEIL(n.rn / 8)
+JOIN account_ids ai ON ai.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM account_ids))
+JOIN riot_accounts ra ON ra.id = ai.id
+WHERE n.rn BETWEEN 8001 AND 12000;
+
+INSERT INTO tft_match_participants (
+    id, gold_left, last_round, level, missions_player_score2,
+    placement, players_eliminated, time_eliminated, total_damage_to_players,
+    win, match_id, puuid, riot_id_game_name, riot_id_tagline,
+    companion, traits, units
+)
+SELECT 
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 3) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
+    FLOOR(RAND() * 100), 
+    FLOOR(20 + RAND() * 20),
+    FLOOR(5 + RAND() * 4),
+    FLOOR(RAND() * 1000),
+    1 + ((n.rn-1) % 8),
+    FLOOR(RAND() * 3),
+    FLOOR(1000 + RAND() * 1000),
+    FLOOR(1000 + RAND() * 5000),
+    IF(((n.rn-1) % 8) = 0, 1, 0),
+    tmi.id,
+    ra.puuid,
+    ra.game_name,
+    ra.tag_line,
+    '{"content_ID": "1", "skin_ID": 1}',
+    '[{"name":"Set10_Breakout","num_units":2,"style":1,"tier_current":1}]',
+    '[{"character_id":"TFT10_Ahri","items":[1,2,3],"name":"Ahri","rarity":4,"tier":2}]'
+FROM 
+    numbers_table n
+JOIN tft_match_ids tmi ON tmi.rn = CEIL(n.rn / 8)
+JOIN account_ids ai ON ai.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM account_ids))
+JOIN riot_accounts ra ON ra.id = ai.id
+WHERE n.rn BETWEEN 12001 AND 16000;
+
+INSERT INTO tft_match_participants (
+    id, gold_left, last_round, level, missions_player_score2,
+    placement, players_eliminated, time_eliminated, total_damage_to_players,
+    win, match_id, puuid, riot_id_game_name, riot_id_tagline,
+    companion, traits, units
+)
+SELECT 
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 3) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
+    FLOOR(RAND() * 100), 
+    FLOOR(20 + RAND() * 20),
+    FLOOR(5 + RAND() * 4),
+    FLOOR(RAND() * 1000),
+    1 + ((n.rn-1) % 8),
+    FLOOR(RAND() * 3),
+    FLOOR(1000 + RAND() * 1000),
+    FLOOR(1000 + RAND() * 5000),
+    IF(((n.rn-1) % 8) = 0, 1, 0),
+    tmi.id,
+    ra.puuid,
+    ra.game_name,
+    ra.tag_line,
+    '{"content_ID": "1", "skin_ID": 1}',
+    '[{"name":"Set10_Breakout","num_units":2,"style":1,"tier_current":1}]',
+    '[{"character_id":"TFT10_Ahri","items":[1,2,3],"name":"Ahri","rarity":4,"tier":2}]'
+FROM 
+    numbers_table n
+JOIN tft_match_ids tmi ON tmi.rn = CEIL(n.rn / 8)
+JOIN account_ids ai ON ai.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM account_ids))
+JOIN riot_accounts ra ON ra.id = ai.id
+WHERE n.rn BETWEEN 16001 AND 20000;
+
+INSERT INTO tft_match_participants (
+    id, gold_left, last_round, level, missions_player_score2,
+    placement, players_eliminated, time_eliminated, total_damage_to_players,
+    win, match_id, puuid, riot_id_game_name, riot_id_tagline,
+    companion, traits, units
+)
+SELECT 
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 3) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
+    FLOOR(RAND() * 100), 
+    FLOOR(20 + RAND() * 20),
+    FLOOR(5 + RAND() * 4),
+    FLOOR(RAND() * 1000),
+    1 + ((n.rn-1) % 8),
+    FLOOR(RAND() * 3),
+    FLOOR(1000 + RAND() * 1000),
+    FLOOR(1000 + RAND() * 5000),
+    IF(((n.rn-1) % 8) = 0, 1, 0),
+    tmi.id,
+    ra.puuid,
+    ra.game_name,
+    ra.tag_line,
+    '{"content_ID": "1", "skin_ID": 1}',
+    '[{"name":"Set10_Breakout","num_units":2,"style":1,"tier_current":1}]',
+    '[{"character_id":"TFT10_Ahri","items":[1,2,3],"name":"Ahri","rarity":4,"tier":2}]'
+FROM 
+    numbers_table n
+JOIN tft_match_ids tmi ON tmi.rn = CEIL(n.rn / 8)
+JOIN account_ids ai ON ai.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM account_ids))
+JOIN riot_accounts ra ON ra.id = ai.id
+WHERE n.rn BETWEEN 20001 AND 24000;
+
+INSERT INTO tft_match_participants (
+    id, gold_left, last_round, level, missions_player_score2,
+    placement, players_eliminated, time_eliminated, total_damage_to_players,
+    win, match_id, puuid, riot_id_game_name, riot_id_tagline,
+    companion, traits, units
+)
+SELECT 
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 3) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
+    FLOOR(RAND() * 100), 
+    FLOOR(20 + RAND() * 20),
+    FLOOR(5 + RAND() * 4),
+    FLOOR(RAND() * 1000),
+    1 + ((n.rn-1) % 8),
+    FLOOR(RAND() * 3),
+    FLOOR(1000 + RAND() * 1000),
+    FLOOR(1000 + RAND() * 5000),
+    IF(((n.rn-1) % 8) = 0, 1, 0),
+    tmi.id,
+    ra.puuid,
+    ra.game_name,
+    ra.tag_line,
+    '{"content_ID": "1", "skin_ID": 1}',
+    '[{"name":"Set10_Breakout","num_units":2,"style":1,"tier_current":1}]',
+    '[{"character_id":"TFT10_Ahri","items":[1,2,3],"name":"Ahri","rarity":4,"tier":2}]'
+FROM 
+    numbers_table n
+JOIN tft_match_ids tmi ON tmi.rn = CEIL(n.rn / 8)
+JOIN account_ids ai ON ai.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM account_ids))
+JOIN riot_accounts ra ON ra.id = ai.id
+WHERE n.rn BETWEEN 24001 AND 28000;
+
+INSERT INTO tft_match_participants (
+    id, gold_left, last_round, level, missions_player_score2,
+    placement, players_eliminated, time_eliminated, total_damage_to_players,
+    win, match_id, puuid, riot_id_game_name, riot_id_tagline,
+    companion, traits, units
+)
+SELECT 
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 3) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
+    FLOOR(RAND() * 100), 
+    FLOOR(20 + RAND() * 20),
+    FLOOR(5 + RAND() * 4),
+    FLOOR(RAND() * 1000),
+    1 + ((n.rn-1) % 8),
+    FLOOR(RAND() * 3),
+    FLOOR(1000 + RAND() * 1000),
+    FLOOR(1000 + RAND() * 5000),
+    IF(((n.rn-1) % 8) = 0, 1, 0),
+    tmi.id,
+    ra.puuid,
+    ra.game_name,
+    ra.tag_line,
+    '{"content_ID": "1", "skin_ID": 1}',
+    '[{"name":"Set10_Breakout","num_units":2,"style":1,"tier_current":1}]',
+    '[{"character_id":"TFT10_Ahri","items":[1,2,3],"name":"Ahri","rarity":4,"tier":2}]'
+FROM 
+    numbers_table n
+JOIN tft_match_ids tmi ON tmi.rn = CEIL(n.rn / 8)
+JOIN account_ids ai ON ai.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM account_ids))
+JOIN riot_accounts ra ON ra.id = ai.id
+WHERE n.rn BETWEEN 28001 AND 32000;
+
+INSERT INTO tft_match_participants (
+    id, gold_left, last_round, level, missions_player_score2,
+    placement, players_eliminated, time_eliminated, total_damage_to_players,
+    win, match_id, puuid, riot_id_game_name, riot_id_tagline,
+    companion, traits, units
+)
+SELECT 
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 3) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
+    FLOOR(RAND() * 100), 
+    FLOOR(20 + RAND() * 20),
+    FLOOR(5 + RAND() * 4),
+    FLOOR(RAND() * 1000),
+    1 + ((n.rn-1) % 8),
+    FLOOR(RAND() * 3),
+    FLOOR(1000 + RAND() * 1000),
+    FLOOR(1000 + RAND() * 5000),
+    IF(((n.rn-1) % 8) = 0, 1, 0),
+    tmi.id,
+    ra.puuid,
+    ra.game_name,
+    ra.tag_line,
+    '{"content_ID": "1", "skin_ID": 1}',
+    '[{"name":"Set10_Breakout","num_units":2,"style":1,"tier_current":1}]',
+    '[{"character_id":"TFT10_Ahri","items":[1,2,3],"name":"Ahri","rarity":4,"tier":2}]'
+FROM 
+    numbers_table n
+JOIN tft_match_ids tmi ON tmi.rn = CEIL(n.rn / 8)
+JOIN account_ids ai ON ai.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM account_ids))
+JOIN riot_accounts ra ON ra.id = ai.id
+WHERE n.rn BETWEEN 32001 AND 36000;
+
+INSERT INTO tft_match_participants (
+    id, gold_left, last_round, level, missions_player_score2,
+    placement, players_eliminated, time_eliminated, total_damage_to_players,
+    win, match_id, puuid, riot_id_game_name, riot_id_tagline,
+    companion, traits, units
+)
+SELECT 
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 3) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
+    FLOOR(RAND() * 100), 
+    FLOOR(20 + RAND() * 20),
+    FLOOR(5 + RAND() * 4),
+    FLOOR(RAND() * 1000),
+    1 + ((n.rn-1) % 8),
+    FLOOR(RAND() * 3),
+    FLOOR(1000 + RAND() * 1000),
+    FLOOR(1000 + RAND() * 5000),
+    IF(((n.rn-1) % 8) = 0, 1, 0),
+    tmi.id,
+    ra.puuid,
+    ra.game_name,
+    ra.tag_line,
+    '{"content_ID": "1", "skin_ID": 1}',
+    '[{"name":"Set10_Breakout","num_units":2,"style":1,"tier_current":1}]',
+    '[{"character_id":"TFT10_Ahri","items":[1,2,3],"name":"Ahri","rarity":4,"tier":2}]'
+FROM 
+    numbers_table n
+JOIN tft_match_ids tmi ON tmi.rn = CEIL(n.rn / 8)
+JOIN account_ids ai ON ai.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM account_ids))
+JOIN riot_accounts ra ON ra.id = ai.id
+WHERE n.rn BETWEEN 36001 AND 40000;
+
+INSERT INTO tft_match_participants (
+    id, gold_left, last_round, level, missions_player_score2,
+    placement, players_eliminated, time_eliminated, total_damage_to_players,
+    win, match_id, puuid, riot_id_game_name, riot_id_tagline,
+    companion, traits, units
+)
+SELECT 
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 3) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
+    FLOOR(RAND() * 100), 
+    FLOOR(20 + RAND() * 20),
+    FLOOR(5 + RAND() * 4),
+    FLOOR(RAND() * 1000),
+    1 + ((n.rn-1) % 8),
+    FLOOR(RAND() * 3),
+    FLOOR(1000 + RAND() * 1000),
+    FLOOR(1000 + RAND() * 5000),
+    IF(((n.rn-1) % 8) = 0, 1, 0),
+    tmi.id,
+    ra.puuid,
+    ra.game_name,
+    ra.tag_line,
+    '{"content_ID": "1", "skin_ID": 1}',
+    '[{"name":"Set10_Breakout","num_units":2,"style":1,"tier_current":1}]',
+    '[{"character_id":"TFT10_Ahri","items":[1,2,3],"name":"Ahri","rarity":4,"tier":2}]'
+FROM 
+    numbers_table n
+JOIN tft_match_ids tmi ON tmi.rn = CEIL(n.rn / 8)
+JOIN account_ids ai ON ai.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM account_ids))
+JOIN riot_accounts ra ON ra.id = ai.id
+WHERE n.rn BETWEEN 40001 AND 44000;
+
+INSERT INTO tft_match_participants (
+    id, gold_left, last_round, level, missions_player_score2,
+    placement, players_eliminated, time_eliminated, total_damage_to_players,
+    win, match_id, puuid, riot_id_game_name, riot_id_tagline,
+    companion, traits, units
+)
+SELECT 
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 3) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
+    FLOOR(RAND() * 100), 
+    FLOOR(20 + RAND() * 20),
+    FLOOR(5 + RAND() * 4),
+    FLOOR(RAND() * 1000),
+    1 + ((n.rn-1) % 8),
+    FLOOR(RAND() * 3),
+    FLOOR(1000 + RAND() * 1000),
+    FLOOR(1000 + RAND() * 5000),
+    IF(((n.rn-1) % 8) = 0, 1, 0),
+    tmi.id,
+    ra.puuid,
+    ra.game_name,
+    ra.tag_line,
+    '{"content_ID": "1", "skin_ID": 1}',
+    '[{"name":"Set10_Breakout","num_units":2,"style":1,"tier_current":1}]',
+    '[{"character_id":"TFT10_Ahri","items":[1,2,3],"name":"Ahri","rarity":4,"tier":2}]'
+FROM 
+    numbers_table n
+JOIN tft_match_ids tmi ON tmi.rn = CEIL(n.rn / 8)
+JOIN account_ids ai ON ai.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM account_ids))
+JOIN riot_accounts ra ON ra.id = ai.id
+WHERE n.rn BETWEEN 44001 AND 48000;
+
+INSERT INTO tft_match_participants (
+    id, gold_left, last_round, level, missions_player_score2,
+    placement, players_eliminated, time_eliminated, total_damage_to_players,
+    win, match_id, puuid, riot_id_game_name, riot_id_tagline,
+    companion, traits, units
+)
+SELECT 
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 3) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
+    FLOOR(RAND() * 100), 
+    FLOOR(20 + RAND() * 20),
+    FLOOR(5 + RAND() * 4),
+    FLOOR(RAND() * 1000),
+    1 + ((n.rn-1) % 8),
+    FLOOR(RAND() * 3),
+    FLOOR(1000 + RAND() * 1000),
+    FLOOR(1000 + RAND() * 5000),
+    IF(((n.rn-1) % 8) = 0, 1, 0),
+    tmi.id,
+    ra.puuid,
+    ra.game_name,
+    ra.tag_line,
+    '{"content_ID": "1", "skin_ID": 1}',
+    '[{"name":"Set10_Breakout","num_units":2,"style":1,"tier_current":1}]',
+    '[{"character_id":"TFT10_Ahri","items":[1,2,3],"name":"Ahri","rarity":4,"tier":2}]'
+FROM 
+    numbers_table n
+JOIN tft_match_ids tmi ON tmi.rn = CEIL(n.rn / 8)
+JOIN account_ids ai ON ai.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM account_ids))
+JOIN riot_accounts ra ON ra.id = ai.id
+WHERE n.rn BETWEEN 48001 AND 52000;
+
+INSERT INTO tft_match_participants (
+    id, gold_left, last_round, level, missions_player_score2,
+    placement, players_eliminated, time_eliminated, total_damage_to_players,
+    win, match_id, puuid, riot_id_game_name, riot_id_tagline,
+    companion, traits, units
+)
+SELECT 
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 3) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
+    FLOOR(RAND() * 100), 
+    FLOOR(20 + RAND() * 20),
+    FLOOR(5 + RAND() * 4),
+    FLOOR(RAND() * 1000),
+    1 + ((n.rn-1) % 8),
+    FLOOR(RAND() * 3),
+    FLOOR(1000 + RAND() * 1000),
+    FLOOR(1000 + RAND() * 5000),
+    IF(((n.rn-1) % 8) = 0, 1, 0),
+    tmi.id,
+    ra.puuid,
+    ra.game_name,
+    ra.tag_line,
+    '{"content_ID": "1", "skin_ID": 1}',
+    '[{"name":"Set10_Breakout","num_units":2,"style":1,"tier_current":1}]',
+    '[{"character_id":"TFT10_Ahri","items":[1,2,3],"name":"Ahri","rarity":4,"tier":2}]'
+FROM 
+    numbers_table n
+JOIN tft_match_ids tmi ON tmi.rn = CEIL(n.rn / 8)
+JOIN account_ids ai ON ai.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM account_ids))
+JOIN riot_accounts ra ON ra.id = ai.id
+WHERE n.rn BETWEEN 52001 AND 56000;
+
+INSERT INTO tft_match_participants (
+    id, gold_left, last_round, level, missions_player_score2,
+    placement, players_eliminated, time_eliminated, total_damage_to_players,
+    win, match_id, puuid, riot_id_game_name, riot_id_tagline,
+    companion, traits, units
+)
+SELECT 
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 3) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
+    FLOOR(RAND() * 100), 
+    FLOOR(20 + RAND() * 20),
+    FLOOR(5 + RAND() * 4),
+    FLOOR(RAND() * 1000),
+    1 + ((n.rn-1) % 8),
+    FLOOR(RAND() * 3),
+    FLOOR(1000 + RAND() * 1000),
+    FLOOR(1000 + RAND() * 5000),
+    IF(((n.rn-1) % 8) = 0, 1, 0),
+    tmi.id,
+    ra.puuid,
+    ra.game_name,
+    ra.tag_line,
+    '{"content_ID": "1", "skin_ID": 1}',
+    '[{"name":"Set10_Breakout","num_units":2,"style":1,"tier_current":1}]',
+    '[{"character_id":"TFT10_Ahri","items":[1,2,3],"name":"Ahri","rarity":4,"tier":2}]'
+FROM 
+    numbers_table n
+JOIN tft_match_ids tmi ON tmi.rn = CEIL(n.rn / 8)
+JOIN account_ids ai ON ai.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM account_ids))
+JOIN riot_accounts ra ON ra.id = ai.id
+WHERE n.rn BETWEEN 56001 AND 60000;
+
+INSERT INTO tft_match_participants (
+    id, gold_left, last_round, level, missions_player_score2,
+    placement, players_eliminated, time_eliminated, total_damage_to_players,
+    win, match_id, puuid, riot_id_game_name, riot_id_tagline,
+    companion, traits, units
+)
+SELECT 
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 3) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
+    FLOOR(RAND() * 100), 
+    FLOOR(20 + RAND() * 20),
+    FLOOR(5 + RAND() * 4),
+    FLOOR(RAND() * 1000),
+    1 + ((n.rn-1) % 8),
+    FLOOR(RAND() * 3),
+    FLOOR(1000 + RAND() * 1000),
+    FLOOR(1000 + RAND() * 5000),
+    IF(((n.rn-1) % 8) = 0, 1, 0),
+    tmi.id,
+    ra.puuid,
+    ra.game_name,
+    ra.tag_line,
+    '{"content_ID": "1", "skin_ID": 1}',
+    '[{"name":"Set10_Breakout","num_units":2,"style":1,"tier_current":1}]',
+    '[{"character_id":"TFT10_Ahri","items":[1,2,3],"name":"Ahri","rarity":4,"tier":2}]'
+FROM 
+    numbers_table n
+JOIN tft_match_ids tmi ON tmi.rn = CEIL(n.rn / 8)
+JOIN account_ids ai ON ai.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM account_ids))
+JOIN riot_accounts ra ON ra.id = ai.id
+WHERE n.rn BETWEEN 60001 AND 64000;
+
+INSERT INTO tft_match_participants (
+    id, gold_left, last_round, level, missions_player_score2,
+    placement, players_eliminated, time_eliminated, total_damage_to_players,
+    win, match_id, puuid, riot_id_game_name, riot_id_tagline,
+    companion, traits, units
+)
+SELECT 
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 3) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
+    FLOOR(RAND() * 100), 
+    FLOOR(20 + RAND() * 20),
+    FLOOR(5 + RAND() * 4),
+    FLOOR(RAND() * 1000),
+    1 + ((n.rn-1) % 8),
+    FLOOR(RAND() * 3),
+    FLOOR(1000 + RAND() * 1000),
+    FLOOR(1000 + RAND() * 5000),
+    IF(((n.rn-1) % 8) = 0, 1, 0),
+    tmi.id,
+    ra.puuid,
+    ra.game_name,
+    ra.tag_line,
+    '{"content_ID": "1", "skin_ID": 1}',
+    '[{"name":"Set10_Breakout","num_units":2,"style":1,"tier_current":1}]',
+    '[{"character_id":"TFT10_Ahri","items":[1,2,3],"name":"Ahri","rarity":4,"tier":2}]'
+FROM 
+    numbers_table n
+JOIN tft_match_ids tmi ON tmi.rn = CEIL(n.rn / 8)
+JOIN account_ids ai ON ai.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM account_ids))
+JOIN riot_accounts ra ON ra.id = ai.id
+WHERE n.rn BETWEEN 64001 AND 68000;
+
+INSERT INTO tft_match_participants (
+    id, gold_left, last_round, level, missions_player_score2,
+    placement, players_eliminated, time_eliminated, total_damage_to_players,
+    win, match_id, puuid, riot_id_game_name, riot_id_tagline,
+    companion, traits, units
+)
+SELECT 
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 3) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
+    FLOOR(RAND() * 100), 
+    FLOOR(20 + RAND() * 20),
+    FLOOR(5 + RAND() * 4),
+    FLOOR(RAND() * 1000),
+    1 + ((n.rn-1) % 8),
+    FLOOR(RAND() * 3),
+    FLOOR(1000 + RAND() * 1000),
+    FLOOR(1000 + RAND() * 5000),
+    IF(((n.rn-1) % 8) = 0, 1, 0),
+    tmi.id,
+    ra.puuid,
+    ra.game_name,
+    ra.tag_line,
+    '{"content_ID": "1", "skin_ID": 1}',
+    '[{"name":"Set10_Breakout","num_units":2,"style":1,"tier_current":1}]',
+    '[{"character_id":"TFT10_Ahri","items":[1,2,3],"name":"Ahri","rarity":4,"tier":2}]'
+FROM 
+    numbers_table n
+JOIN tft_match_ids tmi ON tmi.rn = CEIL(n.rn / 8)
+JOIN account_ids ai ON ai.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM account_ids))
+JOIN riot_accounts ra ON ra.id = ai.id
+WHERE n.rn BETWEEN 68001 AND 72000;
+
+INSERT INTO tft_match_participants (
+    id, gold_left, last_round, level, missions_player_score2,
+    placement, players_eliminated, time_eliminated, total_damage_to_players,
+    win, match_id, puuid, riot_id_game_name, riot_id_tagline,
+    companion, traits, units
+)
+SELECT 
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 3) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
+    FLOOR(RAND() * 100), 
+    FLOOR(20 + RAND() * 20),
+    FLOOR(5 + RAND() * 4),
+    FLOOR(RAND() * 1000),
+    1 + ((n.rn-1) % 8),
+    FLOOR(RAND() * 3),
+    FLOOR(1000 + RAND() * 1000),
+    FLOOR(1000 + RAND() * 5000),
+    IF(((n.rn-1) % 8) = 0, 1, 0),
+    tmi.id,
+    ra.puuid,
+    ra.game_name,
+    ra.tag_line,
+    '{"content_ID": "1", "skin_ID": 1}',
+    '[{"name":"Set10_Breakout","num_units":2,"style":1,"tier_current":1}]',
+    '[{"character_id":"TFT10_Ahri","items":[1,2,3],"name":"Ahri","rarity":4,"tier":2}]'
+FROM 
+    numbers_table n
+JOIN tft_match_ids tmi ON tmi.rn = CEIL(n.rn / 8)
+JOIN account_ids ai ON ai.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM account_ids))
+JOIN riot_accounts ra ON ra.id = ai.id
+WHERE n.rn BETWEEN 72001 AND 76000;
+
+INSERT INTO tft_match_participants (
+    id, gold_left, last_round, level, missions_player_score2,
+    placement, players_eliminated, time_eliminated, total_damage_to_players,
+    win, match_id, puuid, riot_id_game_name, riot_id_tagline,
+    companion, traits, units
+)
+SELECT 
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 3) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
+    FLOOR(RAND() * 100), 
+    FLOOR(20 + RAND() * 20),
+    FLOOR(5 + RAND() * 4),
+    FLOOR(RAND() * 1000),
+    1 + ((n.rn-1) % 8),
+    FLOOR(RAND() * 3),
+    FLOOR(1000 + RAND() * 1000),
+    FLOOR(1000 + RAND() * 5000),
+    IF(((n.rn-1) % 8) = 0, 1, 0),
+    tmi.id,
+    ra.puuid,
+    ra.game_name,
+    ra.tag_line,
+    '{"content_ID": "1", "skin_ID": 1}',
+    '[{"name":"Set10_Breakout","num_units":2,"style":1,"tier_current":1}]',
+    '[{"character_id":"TFT10_Ahri","items":[1,2,3],"name":"Ahri","rarity":4,"tier":2}]'
+FROM 
+    numbers_table n
+JOIN tft_match_ids tmi ON tmi.rn = CEIL(n.rn / 8)
+JOIN account_ids ai ON ai.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM account_ids))
+JOIN riot_accounts ra ON ra.id = ai.id
+WHERE n.rn BETWEEN 76001 AND 80000;
+
+-- Store generated tft_match_participant IDs for reference
+CREATE TEMPORARY TABLE tft_participant_ids AS
+SELECT id, ROW_NUMBER() OVER () as rn
+FROM tft_match_participants;
+
+-- Generate rivalry_participants (2000 records, 4 per rivalry)
+INSERT INTO rivalry_participants (id, created_at, riot_account_id, rivalry_id, side)
+SELECT 
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 4) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
+    ri.created_at,
+    ai.id, -- Link to riot_accounts
+    ri.id, -- Link to rivalries
+    CASE WHEN (n.rn % 4) < 2 THEN 'LEFT' ELSE 'RIGHT' END -- Alternate between LEFT and RIGHT
+FROM 
+    numbers_table n
+JOIN rivalry_ids ri ON ri.rn = CEIL(n.rn / 4)
+JOIN account_ids ai ON ai.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM account_ids))
+WHERE n.rn <= 2000;
+
+-- Generate tft_badge_progress (5000 records, 5 per account)
+INSERT INTO tft_badge_progress (id, achievement_count, is_active, last_updated_at, riot_account_id, badge_type)
+SELECT 
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 5) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
+    FLOOR(RAND() * 100), -- Random achievement count between 0 and 99
+    1, -- All active
+    DATE_SUB(CURRENT_TIMESTAMP, INTERVAL FLOOR(RAND() * 30) DAY),
+    ai.id, -- Link to riot_accounts
+    ELT(1 + (n.rn-1) % 5, 'DAMAGE_DEALER', 'EXECUTOR', 'LUXURY', 'MVP', 'STEADY') -- Rotate through badge types
+FROM 
+    numbers_table n
+JOIN account_ids ai ON ai.rn = CEIL(n.rn / 5)
+WHERE n.rn <= 5000;
 
 -- Generate tft_match_achievements (50000 records, ~5 per match)
 INSERT INTO tft_match_achievements (id, value, match_id, participant_id, type)
 SELECT 
-    generate_tsid(),
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 6) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
     FLOOR(RAND() * 1000), -- Random achievement value
-    1 + FLOOR(RAND() * 10000), -- Random match_id between 1 and 10000
-    1 + FLOOR(RAND() * 80000), -- Random participant_id between 1 and 80000
+    tmi.id, -- Link to tft_matches
+    tpi.id, -- Link to tft_match_participants
     ELT(1 + FLOOR(RAND() * 5), 'FIRST_PLACE', 'MOST_DAMAGE_DEALT', 'MOST_ELIMINATIONS', 'MOST_EXPENSIVE_SQUAD', 'TOP_FOUR')
-FROM (
-    SELECT @row := @row + 1 as n
-    FROM (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t1,
-         (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t2,
-         (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t3,
-         (select 0 union all select 1 union all select 2 union all select 3 union all select 4) t4,
-         (SELECT @row:=0) r
-    LIMIT 50000
-) numbers;
+FROM 
+    numbers_table n
+JOIN tft_match_ids tmi ON tmi.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM tft_match_ids))
+JOIN tft_participant_ids tpi ON tpi.rn = 1 + ((n.rn-1) % (SELECT COUNT(*) FROM tft_participant_ids))
+WHERE n.rn <= 50000;
 
 -- Generate tft_league_entries (3000 records, 3 per account for different queue types)
 INSERT INTO tft_league_entries (
@@ -222,6 +798,7 @@ INSERT INTO tft_league_entries (
     queue_type, rank, tier
 )
 SELECT 
+    ((UNIX_TIMESTAMP(NOW(3)) * 1000 + 7) << 22) | (n.rn % (1 << 22)), -- Custom TSID with table offset
     FLOOR(RAND() * 2), -- Random fresh_blood
     FLOOR(RAND() * 2), -- Random hot_streak
     0, -- Not inactive
@@ -232,25 +809,21 @@ SELECT
     NULL,
     FLOOR(RAND() * 2), -- Random veteran
     FLOOR(RAND() * 50), -- Random wins
-    1 + FLOOR((n-1)/3), -- Distribute 3 entries per account
-    n, -- Unique id
+    ai.id, -- Link to riot_accounts
     DATE_SUB(CURRENT_TIMESTAMP, INTERVAL FLOOR(RAND() * 7) DAY),
     1, -- Version
-    CONCAT('01234567-89ab-cdef-', LPAD(n, 4, '0')), -- Unique league_id
+    CONCAT('01234567-89ab-cdef-', LPAD(n.rn, 4, '0')), -- Unique league_id
     NULL, -- No mini series progress
-    (SELECT puuid FROM riot_accounts WHERE id = 1 + FLOOR((n-1)/3) LIMIT 1), -- Matching puuid
-    CONCAT('SUMMONER', LPAD(n, 4, '0')), -- Unique summoner_id
-    ELT(1 + (n-1) % 3, 'RANKED_TFT', 'RANKED_TFT_DOUBLE_UP', 'RANKED_TFT_TURBO'), -- Rotate through queue types
+    ra.puuid, -- Matching puuid from riot_accounts
+    CONCAT('SUMMONER', LPAD(n.rn, 4, '0')), -- Unique summoner_id
+    ELT(1 + (n.rn-1) % 3, 'RANKED_TFT', 'RANKED_TFT_DOUBLE_UP', 'RANKED_TFT_TURBO'), -- Rotate through queue types
     ELT(1 + FLOOR(RAND() * 4), 'I', 'II', 'III', 'IV'), -- Random rank
     ELT(1 + FLOOR(RAND() * 10), 'IRON', 'BRONZE', 'SILVER', 'GOLD', 'PLATINUM', 'EMERALD', 'DIAMOND', 'MASTER', 'GRANDMASTER', 'CHALLENGER') -- Random tier
-FROM (
-    SELECT @row := @row + 1 as n
-    FROM (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t1,
-         (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t2,
-         (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t3,
-         (SELECT @row:=0) r
-    LIMIT 3000
-) numbers;
+FROM 
+    numbers_table n
+JOIN account_ids ai ON ai.rn = CEIL(n.rn / 3)
+JOIN riot_accounts ra ON ra.id = ai.id
+WHERE n.rn <= 3000;
 
 -- Re-enable foreign key checks and unique checks
 SET FOREIGN_KEY_CHECKS=1;

--- a/infra/sql/dummy-data.sql
+++ b/infra/sql/dummy-data.sql
@@ -1,0 +1,257 @@
+-- Disable foreign key checks and unique checks temporarily for faster inserts
+SET FOREIGN_KEY_CHECKS=0;
+SET UNIQUE_CHECKS=0;
+SET SQL_MODE='NO_AUTO_VALUE_ON_ZERO';
+
+-- Drop existing functions if they exist
+DROP FUNCTION IF EXISTS generate_tsid;
+DROP FUNCTION IF EXISTS rand_datetime;
+
+-- Function to generate TSID
+DELIMITER //
+CREATE FUNCTION generate_tsid()
+RETURNS BIGINT
+BEGIN
+    -- Get current timestamp in milliseconds (Unix epoch)
+    SET @now = UNIX_TIMESTAMP(NOW(3)) * 1000;
+    
+    -- Generate random number for the lower bits (0-1023)
+    SET @random = FLOOR(RAND() * 1024);
+    
+    -- Combine timestamp and random number
+    -- Shift timestamp left by 10 bits and combine with random number
+    RETURN (@now << 10) | @random;
+END //
+DELIMITER ;
+
+-- Function to generate random datetime between two dates
+DELIMITER //
+CREATE FUNCTION rand_datetime(min_date DATETIME, max_date DATETIME)
+RETURNS DATETIME
+BEGIN
+    RETURN FROM_UNIXTIME(
+        UNIX_TIMESTAMP(min_date) + FLOOR(
+            RAND() * (
+                UNIX_TIMESTAMP(max_date) - UNIX_TIMESTAMP(min_date)
+            )
+        )
+    );
+END //
+DELIMITER ;
+
+-- Generate riot_accounts (1000 records)
+INSERT INTO riot_accounts (id, created_at, updated_at, game_name, puuid, tag_line)
+SELECT 
+    generate_tsid(), -- TSID instead of sequential number
+    created_dt,
+    updated_dt,
+    CONCAT('Player', LPAD(rn, 4, '0')),
+    CONCAT('PUUID', LPAD(rn, 4, '0'), REPEAT(MD5(RAND()), 2)),
+    CONCAT('TAG', LPAD(rn, 4, '0'))
+FROM (
+    SELECT 
+        @row := @row + 1 as rn,
+        DATE_SUB(CURRENT_TIMESTAMP, INTERVAL FLOOR(RAND() * 365) DAY) as created_dt,
+        DATE_SUB(CURRENT_TIMESTAMP, INTERVAL FLOOR(RAND() * 30) DAY) as updated_dt
+    FROM (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t1,
+         (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t2,
+         (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t3,
+         (SELECT @row:=0) r
+    LIMIT 1000
+) numbers;
+
+-- Store generated IDs for reference
+CREATE TEMPORARY TABLE account_ids
+SELECT id, ROW_NUMBER() OVER () as rn
+FROM riot_accounts;
+
+-- Generate rivalries (500 records)
+INSERT INTO rivalries (id, created_at)
+SELECT 
+    generate_tsid(),
+    DATE_SUB(CURRENT_TIMESTAMP, INTERVAL FLOOR(RAND() * 365) DAY)
+FROM (
+    SELECT @row := @row + 1 as rn
+    FROM (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t1,
+         (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t2,
+         (SELECT @row:=0) r
+    LIMIT 500
+) numbers;
+
+-- Store generated rivalry IDs for reference
+CREATE TEMPORARY TABLE rivalry_ids
+SELECT id, ROW_NUMBER() OVER () as rn
+FROM rivalries;
+
+-- Generate rivalry_participants (2000 records, 4 per rivalry)
+INSERT INTO rivalry_participants (id, created_at, riot_account_id, rivalry_id, side)
+SELECT 
+    generate_tsid(),
+    r.created_at,
+    1 + FLOOR(RAND() * 1000), -- Random riot_account_id between 1 and 1000
+    1 + FLOOR((n-1)/4), -- Distribute 4 participants per rivalry
+    CASE WHEN (n % 4) < 2 THEN 'LEFT' ELSE 'RIGHT' END -- Alternate between LEFT and RIGHT
+FROM (
+    SELECT @row := @row + 1 as n
+    FROM (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t1,
+         (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t2,
+         (select 0 union all select 1 union all select 2 union all select 3 union all select 4) t3,
+         (SELECT @row:=0) r
+    LIMIT 2000
+) numbers
+JOIN rivalries r ON r.id = 1 + FLOOR((numbers.n-1)/4);
+
+-- Generate tft_badge_progress (5000 records, 5 per account)
+INSERT INTO tft_badge_progress (id, achievement_count, is_active, last_updated_at, riot_account_id, badge_type)
+SELECT 
+    generate_tsid(),
+    FLOOR(RAND() * 100), -- Random achievement count between 0 and 99
+    1, -- All active
+    DATE_SUB(CURRENT_TIMESTAMP, INTERVAL FLOOR(RAND() * 30) DAY),
+    1 + FLOOR((n-1)/5), -- Distribute 5 badges per account
+    ELT(1 + (n-1) % 5, 'DAMAGE_DEALER', 'EXECUTOR', 'LUXURY', 'MVP', 'STEADY') -- Rotate through badge types
+FROM (
+    SELECT @row := @row + 1 as n
+    FROM (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t1,
+         (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t2,
+         (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t3,
+         (SELECT @row:=0) r
+    LIMIT 5000
+) numbers;
+
+-- Generate tft_matches (10000 records)
+INSERT INTO tft_matches (
+    id, game_length, map_id, queue_id, tft_set_number,
+    created_at, game_creation, game_date_time, game_id,
+    data_version, end_of_game_result, game_version,
+    match_id, tft_game_type, tft_set_core_name
+)
+SELECT 
+    generate_tsid(),
+    1200 + RAND() * 600, -- Game length between 1200 and 1800 seconds
+    1,
+    1100, -- Ranked queue_id
+    10, -- Set 10
+    DATE_SUB(CURRENT_TIMESTAMP, INTERVAL FLOOR(RAND() * 30) DAY),
+    UNIX_TIMESTAMP(DATE_SUB(CURRENT_TIMESTAMP, INTERVAL FLOOR(RAND() * 30) DAY)) * 1000,
+    UNIX_TIMESTAMP(DATE_SUB(CURRENT_TIMESTAMP, INTERVAL FLOOR(RAND() * 30) DAY)) * 1000,
+    n + 1000000, -- Unique game_id
+    '3',
+    'FINISHED',
+    '13.24.1',
+    CONCAT('KR_', n + 1000000),
+    'RANKED_TFT',
+    'TFT_SET10'
+FROM (
+    SELECT @row := @row + 1 as n
+    FROM (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t1,
+         (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t2,
+         (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t3,
+         (select 0 union all select 1) t4,
+         (SELECT @row:=0) r
+    LIMIT 10000
+) numbers;
+
+-- Generate tft_match_participants (80000 records, 8 per match)
+INSERT INTO tft_match_participants (
+    id, gold_left, last_round, level, missions_player_score2,
+    placement, players_eliminated, time_eliminated, total_damage_to_players,
+    win, match_id, puuid, riot_id_game_name, riot_id_tagline,
+    companion, traits, units
+)
+SELECT 
+    generate_tsid(),
+    FLOOR(RAND() * 100), -- Random gold_left
+    FLOOR(20 + RAND() * 20), -- Random last_round between 20 and 39
+    FLOOR(5 + RAND() * 4), -- Random level between 5 and 8
+    FLOOR(RAND() * 1000), -- Random mission score
+    1 + ((n-1) % 8), -- Placement 1-8 for each match
+    FLOOR(RAND() * 3), -- Random players eliminated
+    FLOOR(1000 + RAND() * 1000), -- Random time eliminated
+    FLOOR(1000 + RAND() * 5000), -- Random damage dealt
+    IF(((n-1) % 8) = 0, 1, 0), -- First player in each match wins
+    1 + FLOOR((n-1)/8), -- Distribute 8 participants per match
+    ra.puuid,
+    ra.game_name,
+    ra.tag_line,
+    '{"content_ID": "1", "skin_ID": 1}', -- Simple companion JSON
+    '[{"name":"Set10_Breakout","num_units":2,"style":1,"tier_current":1}]', -- Simple traits JSON
+    '[{"character_id":"TFT10_Ahri","items":[1,2,3],"name":"Ahri","rarity":4,"tier":2}]' -- Simple units JSON
+FROM (
+    SELECT @row := @row + 1 as n
+    FROM (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t1,
+         (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t2,
+         (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t3,
+         (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t4,
+         (SELECT @row:=0) r
+    LIMIT 80000
+) numbers
+JOIN (
+    SELECT id % 1000 + 1 as random_id, puuid, game_name, tag_line
+    FROM (
+        SELECT @raid := @raid + 1 as id, puuid, game_name, tag_line
+        FROM riot_accounts,
+        (SELECT @raid:=0) r
+    ) t
+) ra ON ra.random_id = 1 + (numbers.n % 1000);
+
+-- Generate tft_match_achievements (50000 records, ~5 per match)
+INSERT INTO tft_match_achievements (id, value, match_id, participant_id, type)
+SELECT 
+    generate_tsid(),
+    FLOOR(RAND() * 1000), -- Random achievement value
+    1 + FLOOR(RAND() * 10000), -- Random match_id between 1 and 10000
+    1 + FLOOR(RAND() * 80000), -- Random participant_id between 1 and 80000
+    ELT(1 + FLOOR(RAND() * 5), 'FIRST_PLACE', 'MOST_DAMAGE_DEALT', 'MOST_ELIMINATIONS', 'MOST_EXPENSIVE_SQUAD', 'TOP_FOUR')
+FROM (
+    SELECT @row := @row + 1 as n
+    FROM (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t1,
+         (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t2,
+         (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t3,
+         (select 0 union all select 1 union all select 2 union all select 3 union all select 4) t4,
+         (SELECT @row:=0) r
+    LIMIT 50000
+) numbers;
+
+-- Generate tft_league_entries (3000 records, 3 per account for different queue types)
+INSERT INTO tft_league_entries (
+    fresh_blood, hot_streak, inactive, league_points, losses,
+    mini_series_losses, mini_series_target, mini_series_wins,
+    veteran, wins, account_id, id, updated_at, version,
+    league_id, mini_series_progress, puuid, summoner_id,
+    queue_type, rank, tier
+)
+SELECT 
+    FLOOR(RAND() * 2), -- Random fresh_blood
+    FLOOR(RAND() * 2), -- Random hot_streak
+    0, -- Not inactive
+    FLOOR(RAND() * 100), -- Random LP
+    FLOOR(RAND() * 50), -- Random losses
+    NULL, -- No mini series
+    NULL,
+    NULL,
+    FLOOR(RAND() * 2), -- Random veteran
+    FLOOR(RAND() * 50), -- Random wins
+    1 + FLOOR((n-1)/3), -- Distribute 3 entries per account
+    n, -- Unique id
+    DATE_SUB(CURRENT_TIMESTAMP, INTERVAL FLOOR(RAND() * 7) DAY),
+    1, -- Version
+    CONCAT('01234567-89ab-cdef-', LPAD(n, 4, '0')), -- Unique league_id
+    NULL, -- No mini series progress
+    (SELECT puuid FROM riot_accounts WHERE id = 1 + FLOOR((n-1)/3) LIMIT 1), -- Matching puuid
+    CONCAT('SUMMONER', LPAD(n, 4, '0')), -- Unique summoner_id
+    ELT(1 + (n-1) % 3, 'RANKED_TFT', 'RANKED_TFT_DOUBLE_UP', 'RANKED_TFT_TURBO'), -- Rotate through queue types
+    ELT(1 + FLOOR(RAND() * 4), 'I', 'II', 'III', 'IV'), -- Random rank
+    ELT(1 + FLOOR(RAND() * 10), 'IRON', 'BRONZE', 'SILVER', 'GOLD', 'PLATINUM', 'EMERALD', 'DIAMOND', 'MASTER', 'GRANDMASTER', 'CHALLENGER') -- Random tier
+FROM (
+    SELECT @row := @row + 1 as n
+    FROM (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t1,
+         (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t2,
+         (select 0 union all select 1 union all select 2 union all select 3 union all select 4 union all select 5 union all select 6 union all select 7 union all select 8 union all select 9) t3,
+         (SELECT @row:=0) r
+    LIMIT 3000
+) numbers;
+
+-- Re-enable foreign key checks and unique checks
+SET FOREIGN_KEY_CHECKS=1;
+SET UNIQUE_CHECKS=1; 


### PR DESCRIPTION
# TftMatch 및 TfTMatchParticipant 인덱스 최적화

## 개요

TFT 매치 조회 성능을 개선하기 위해 관련 테이블의 인덱스를 추가하고 최적화했습니다. 특히 매치 목록 조회와 매치 참가자 조회 시의 성능을 개선하는데 중점을 두었습니다.

## 주요 변경사항

### 1. TFT 매치 테이블 인덱스 추가
- `tft_matches` 테이블에 게임 생성 시간 기준 인덱스 추가
  - `idx_game_creation_id_desc`: (gameCreation DESC, id) 복합 인덱스 추가
  - 최근 매치 조회 성능 개선을 위한 인덱스 구성

### 2. TFT 매치 참가자 테이블 인덱스 추가
- `tft_match_participants` 테이블에 매치-PUUID 복합 인덱스 추가
  - `idx_match_puuid`: (match_id, puuid) 복합 인덱스 추가
  - 특정 소환사의 매치 참가 정보 조회 성능 개선

### 3. 데이터베이스 설정 변경
- Hibernate DDL 설정 변경
  - `ddl-auto` 설정을 `create-drop`에서 `update`로 변경
  - 개발 환경에서 데이터 유지를 위한 설정 적용

### 4. 테스트 데이터 구성
- 테스트용 DDL 및 더미 데이터 스크립트 추가
  - 테이블 구조 정의 스크립트 추가
  - 성능 테스트를 위한 대량의 더미 데이터 생성 스크립트 구성 (#36 참조)

## 테스트
- 인덱스 적용 후 쿼리 성능 개선 확인
- 더미 데이터를 통한 N만 건 데이터 환경에서의 성능 검증

## 관련 이슈
Fixes #35 #36

이 PR은 TFT 매치 조회 관련 쿼리의 성능을 개선하여 사용자 경험을 향상시켰습니다. 특히 최근 매치 목록 조회와 매치 참가자 정보 조회 시의 응답 속도가 개선되었습니다.