### PR TITLE
API 에러 처리 로직 개선 및 커스텀 예외 도입

### DIFF
--- a/api/src/main/java/com/glennsyj/rivals/api/common/client/BaseRiotClient.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/common/client/BaseRiotClient.java
@@ -1,5 +1,6 @@
 package com.glennsyj.rivals.api.common.client;
 
+import com.glennsyj.rivals.api.common.exception.RiotApiException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -33,22 +34,28 @@ public abstract class BaseRiotClient {
         try {
             return apiCall
                     .retryWhen(Retry.backoff(MAX_RETRIES, INITIAL_BACKOFF)
-                            .filter(throwable -> shouldRetry(throwable))
+                            .filter(this::shouldRetry)
                             .doBeforeRetry(retrySignal -> 
                                 logger.warn("Retrying API call after error. Attempt {}/{}",
                                     retrySignal.totalRetries() + 1, MAX_RETRIES)))
                     .blockOptional()
-                    .orElseThrow(() -> new IllegalStateException(errorMessage));
+                    .orElseThrow(() -> new RiotApiException(errorMessage));
         } catch (WebClientResponseException e) {
             if (e.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS) {
                 String retryAfter = e.getHeaders().getFirst("Retry-After");
                 logger.error("Rate limit exceeded. Retry after {} seconds", retryAfter);
-                throw new IllegalStateException("Riot API 호출 횟수 제한 초과. " + retryAfter + "초 후에 다시 시도해주세요.", e);
+                throw new RiotApiException(
+                    "Riot API 호출 횟수 제한 초과. " + retryAfter + "초 후에 다시 시도해주세요.",
+                    e.getStatusCode().value()
+                );
             }
-            throw new IllegalStateException("Riot API 호출 실패: " + e.getResponseBodyAsString(), e);
+            throw new RiotApiException(
+                "Riot API 호출 실패: " + e.getResponseBodyAsString(),
+                e.getStatusCode().value()
+            );
         } finally {
             long duration = System.currentTimeMillis() - startTime;
-            logger.info("Riot API call for '{}' completed in {}ms", this.getClass(), duration);
+            logger.info("Riot API call for '{}' completed in {}ms", this.getClass().getSimpleName(), duration);
         }
     }
 

--- a/api/src/main/java/com/glennsyj/rivals/api/common/exception/CustomException.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/common/exception/CustomException.java
@@ -1,0 +1,21 @@
+package com.glennsyj.rivals.api.common.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.ErrorResponseException;
+import java.net.URI;
+
+public abstract class CustomException extends ErrorResponseException {
+
+    protected CustomException(HttpStatus status, String title, String detail, URI type) {
+        super(status, ProblemDetail.forStatusAndDetail(status, detail), null);
+        getBody().setTitle(title);
+        if (type != null) {
+            getBody().setType(type);
+        }
+    }
+
+    protected CustomException(HttpStatus status, ProblemDetail problemDetail) {
+        super(status, problemDetail, null);
+    }
+} 

--- a/api/src/main/java/com/glennsyj/rivals/api/common/exception/GlobalExceptionHandler.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/common/exception/GlobalExceptionHandler.java
@@ -91,5 +91,14 @@ public class GlobalExceptionHandler {
         return ResponseEntity.of(problemDetail).build();
     }
 
-    // TODO: Sub-issue 3: 커스텀 비즈니스 예외 정의 및 적용 시 여기에 핸들러 추가 예정
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ProblemDetail> handleCustomException(CustomException ex, HttpServletRequest request) {
+        log.warn("Custom business exception: {}", ex.getBody().getDetail());
+
+        // CustomException에서 생성된 ProblemDetail을 그대로 사용
+        ProblemDetail problemDetail = ex.getBody();
+        problemDetail.setInstance(URI.create(request.getRequestURI()));
+
+        return ResponseEntity.of(problemDetail).build();
+    }
 }

--- a/api/src/main/java/com/glennsyj/rivals/api/common/exception/GlobalExceptionHandler.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,87 @@
+package com.glennsyj.rivals.api.common.exception;
+
+import com.glennsyj.rivals.api.common.model.ErrorDetail;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.web.ErrorResponse;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ProblemDetail> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
+        log.warn("Validation failed: {}", ex.getMessage());
+
+        ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
+        problemDetail.setTitle("Validation Error");
+        problemDetail.setDetail("입력 값 유효성 검사에 실패했습니다.");
+
+        return ResponseEntity.of(problemDetail).build();
+    }
+
+    @ExceptionHandler(NoSuchElementException.class)
+    public ResponseEntity<ProblemDetail> handleNoSuchElementException(NoSuchElementException ex) {
+        log.warn("Resource not found: {}", ex.getMessage());
+
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
+                HttpStatus.NOT_FOUND,
+                ex.getMessage() != null ? ex.getMessage() : "요청하신 리소스를 찾을 수 없습니다."
+        );
+        problemDetail.setTitle("Resource Not Found"); // ProblemDetail.forStatusAndDetail은 title을 설정하지 않으므로 필요시 추가
+        ErrorResponse err;
+        return ResponseEntity.of(problemDetail).build();
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<ProblemDetail> handleHttpMessageNotReadableException(HttpMessageNotReadableException ex) {
+        log.warn("Malformed JSON request: {}", ex.getMessage());
+
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
+                HttpStatus.BAD_REQUEST,
+                "요청 본문 형식이 잘못되었거나 읽을 수 없습니다. JSON 형식을 확인해주세요."
+        );
+        problemDetail.setTitle("Malformed Request Body");
+
+        return ResponseEntity.of(problemDetail).build();
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ProblemDetail> handleIllegalArgumentException(IllegalArgumentException ex) {
+        log.warn("Illegal argument: {}", ex.getMessage());
+
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
+                HttpStatus.BAD_REQUEST,
+                ex.getMessage() != null ? ex.getMessage() : "잘못된 요청 인자입니다."
+        );
+        problemDetail.setTitle("Bad Request");
+
+        return ResponseEntity.of(problemDetail).build();
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ProblemDetail> handleGenericException(Exception ex) {
+        log.error("An unexpected error occurred: {}", ex.getMessage(), ex); // 스택 트레이스와 함께 에러 로그 기록
+
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
+                HttpStatus.INTERNAL_SERVER_ERROR,
+                "서버에서 예기치 않은 오류가 발생했습니다. 잠시 후 다시 시도해주세요."
+        );
+        problemDetail.setTitle("Internal Server Error");
+        return ResponseEntity.of(problemDetail).build();
+    }
+
+    // TODO: Sub-issue 3: 커스텀 비즈니스 예외 정의 및 적용 시 여기에 핸들러 추가 예정
+}

--- a/api/src/main/java/com/glennsyj/rivals/api/common/exception/GlobalExceptionHandler.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.glennsyj.rivals.api.common.exception;
 
 import com.glennsyj.rivals.api.common.model.ErrorDetail;
+import jakarta.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.net.URI;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
@@ -22,31 +24,33 @@ public class GlobalExceptionHandler {
     private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<ProblemDetail> handleMethodArgumentNotValid(MethodArgumentNotValidException ex) {
+    public ResponseEntity<ProblemDetail> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpServletRequest request) {
         log.warn("Validation failed: {}", ex.getMessage());
 
         ProblemDetail problemDetail = ProblemDetail.forStatus(HttpStatus.BAD_REQUEST);
         problemDetail.setTitle("Validation Error");
         problemDetail.setDetail("입력 값 유효성 검사에 실패했습니다.");
+        problemDetail.setInstance(URI.create(request.getRequestURI()));
 
         return ResponseEntity.of(problemDetail).build();
     }
 
     @ExceptionHandler(NoSuchElementException.class)
-    public ResponseEntity<ProblemDetail> handleNoSuchElementException(NoSuchElementException ex) {
+    public ResponseEntity<ProblemDetail> handleNoSuchElementException(NoSuchElementException ex, HttpServletRequest request) {
         log.warn("Resource not found: {}", ex.getMessage());
 
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
                 HttpStatus.NOT_FOUND,
                 ex.getMessage() != null ? ex.getMessage() : "요청하신 리소스를 찾을 수 없습니다."
         );
-        problemDetail.setTitle("Resource Not Found"); // ProblemDetail.forStatusAndDetail은 title을 설정하지 않으므로 필요시 추가
-        ErrorResponse err;
+        problemDetail.setTitle("Resource Not Found");
+        problemDetail.setInstance(URI.create(request.getRequestURI()));
+
         return ResponseEntity.of(problemDetail).build();
     }
 
     @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ResponseEntity<ProblemDetail> handleHttpMessageNotReadableException(HttpMessageNotReadableException ex) {
+    public ResponseEntity<ProblemDetail> handleHttpMessageNotReadableException(HttpMessageNotReadableException ex, HttpServletRequest request) {
         log.warn("Malformed JSON request: {}", ex.getMessage());
 
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
@@ -54,12 +58,13 @@ public class GlobalExceptionHandler {
                 "요청 본문 형식이 잘못되었거나 읽을 수 없습니다. JSON 형식을 확인해주세요."
         );
         problemDetail.setTitle("Malformed Request Body");
+        problemDetail.setInstance(URI.create(request.getRequestURI()));
 
         return ResponseEntity.of(problemDetail).build();
     }
 
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ProblemDetail> handleIllegalArgumentException(IllegalArgumentException ex) {
+    public ResponseEntity<ProblemDetail> handleIllegalArgumentException(IllegalArgumentException ex, HttpServletRequest request) {
         log.warn("Illegal argument: {}", ex.getMessage());
 
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
@@ -67,12 +72,13 @@ public class GlobalExceptionHandler {
                 ex.getMessage() != null ? ex.getMessage() : "잘못된 요청 인자입니다."
         );
         problemDetail.setTitle("Bad Request");
+        problemDetail.setInstance(URI.create(request.getRequestURI()));
 
         return ResponseEntity.of(problemDetail).build();
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ProblemDetail> handleGenericException(Exception ex) {
+    public ResponseEntity<ProblemDetail> handleGenericException(Exception ex, HttpServletRequest request) {
         log.error("An unexpected error occurred: {}", ex.getMessage(), ex); // 스택 트레이스와 함께 에러 로그 기록
 
         ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
@@ -80,6 +86,8 @@ public class GlobalExceptionHandler {
                 "서버에서 예기치 않은 오류가 발생했습니다. 잠시 후 다시 시도해주세요."
         );
         problemDetail.setTitle("Internal Server Error");
+        problemDetail.setInstance(URI.create(request.getRequestURI()));
+
         return ResponseEntity.of(problemDetail).build();
     }
 

--- a/api/src/main/java/com/glennsyj/rivals/api/common/exception/RiotAccountNotFoundException.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/common/exception/RiotAccountNotFoundException.java
@@ -1,0 +1,18 @@
+package com.glennsyj.rivals.api.common.exception;
+
+import org.springframework.http.HttpStatus;
+import java.net.URI;
+
+public class RiotAccountNotFoundException extends CustomException {
+
+    private static final String TITLE = "Riot Account Not Found";
+
+    public RiotAccountNotFoundException(Long accountId) {
+        super(HttpStatus.NOT_FOUND, TITLE, "ID " + accountId + "에 해당하는 Riot 계정을 찾을 수 없습니다.", null);
+        getBody().setProperty("accountId", accountId);
+    }
+
+    public RiotAccountNotFoundException(String message) {
+        super(HttpStatus.NOT_FOUND, TITLE, message, null);
+    }
+} 

--- a/api/src/main/java/com/glennsyj/rivals/api/common/exception/RiotApiException.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/common/exception/RiotApiException.java
@@ -1,0 +1,20 @@
+package com.glennsyj.rivals.api.common.exception;
+
+import org.springframework.http.HttpStatus;
+import java.net.URI;
+
+public class RiotApiException extends CustomException {
+
+    private static final String TITLE = "Riot API Error";
+
+    public RiotApiException(String message) {
+        super(HttpStatus.INTERNAL_SERVER_ERROR, TITLE, message, null);
+    }
+
+    public RiotApiException(String message, Integer riotApiStatusCode) {
+        super(HttpStatus.INTERNAL_SERVER_ERROR, TITLE, message, null);
+        if (riotApiStatusCode != null) {
+            getBody().setProperty("riotApiStatusCode", riotApiStatusCode);
+        }
+    }
+} 

--- a/api/src/main/java/com/glennsyj/rivals/api/common/exception/RivalryNotFoundException.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/common/exception/RivalryNotFoundException.java
@@ -1,0 +1,18 @@
+package com.glennsyj.rivals.api.common.exception;
+
+import org.springframework.http.HttpStatus;
+import java.net.URI;
+
+public class RivalryNotFoundException extends CustomException {
+
+    private static final String TITLE = "Rivalry Not Found";
+
+    public RivalryNotFoundException(Long rivalryId) {
+        super(HttpStatus.NOT_FOUND, TITLE, "ID " + rivalryId + "에 해당하는 Rivalry를 찾을 수 없습니다.", null);
+        getBody().setProperty("rivalryId", rivalryId);
+    }
+
+    public RivalryNotFoundException(String message) {
+        super(HttpStatus.NOT_FOUND, TITLE, message, null);
+    }
+} 

--- a/api/src/main/java/com/glennsyj/rivals/api/common/exception/TftNoGameException.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/common/exception/TftNoGameException.java
@@ -1,0 +1,16 @@
+package com.glennsyj.rivals.api.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class TftNoGameException extends CustomException {
+    private static final String TITLE = "Tft No Game Yet";
+
+    public TftNoGameException(Long accountId) {
+        super(HttpStatus.NOT_FOUND, TITLE, "ID " + accountId + "는 아직 TFT 게임을 진행하지 않았습니다.", null);
+        getBody().setProperty("accountId", accountId);
+    }
+
+    public TftNoGameException(String message) {
+        super(HttpStatus.NOT_FOUND, TITLE, message, null);
+    }
+}

--- a/api/src/main/java/com/glennsyj/rivals/api/common/model/ErrorDetail.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/common/model/ErrorDetail.java
@@ -1,0 +1,6 @@
+package com.glennsyj.rivals.api.common.model;
+
+public record ErrorDetail (
+    String field,
+    String message
+){ }

--- a/api/src/main/java/com/glennsyj/rivals/api/riot/controller/RiotController.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/riot/controller/RiotController.java
@@ -26,24 +26,14 @@ public class RiotController {
     @GetMapping("/accounts/{gameName}/{tagLine}")
     public ResponseEntity<RiotAccountDto> findAccount(@PathVariable("gameName") String gameName
             , @PathVariable("tagLine") String tagLine) {
-        try {
-            RiotAccount account = riotAccountManager.findOrRegisterAccount(gameName, tagLine);
-            return ResponseEntity.ok(RiotAccountDto.from(account));
-        } catch (IllegalStateException e) {
-            log.error(e.getMessage());
-            return ResponseEntity.notFound().build();
-        }
+        RiotAccount account = riotAccountManager.findOrRegisterAccount(gameName, tagLine);
+        return ResponseEntity.ok(RiotAccountDto.from(account));
     }
 
     @PatchMapping("/accounts/renew/{gameName}/{tagLine}")
     public ResponseEntity<RiotAccountDto> renewAccount(@PathVariable("gameName") String gameName
             , @PathVariable("tagLine") String tagLine) {
-        try {
-            RiotAccount account = riotAccountManager.renewAccount(gameName, tagLine);
-            return ResponseEntity.ok(RiotAccountDto.from(account));
-        } catch (IllegalStateException e) {
-            log.error("Failed to renew account for {}#{}: {}", gameName, tagLine, e.getMessage());
-            return ResponseEntity.notFound().build();
-        }
+        RiotAccount account = riotAccountManager.renewAccount(gameName, tagLine);
+        return ResponseEntity.ok(RiotAccountDto.from(account));
     }
 }

--- a/api/src/main/java/com/glennsyj/rivals/api/riot/service/RiotAccountManager.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/riot/service/RiotAccountManager.java
@@ -1,5 +1,6 @@
 package com.glennsyj.rivals.api.riot.service;
 
+import com.glennsyj.rivals.api.common.exception.RiotAccountNotFoundException;
 import com.glennsyj.rivals.api.riot.RiotAccountClient;
 import com.glennsyj.rivals.api.riot.entity.RiotAccount;
 import com.glennsyj.rivals.api.riot.model.RiotAccountResponse;
@@ -40,7 +41,8 @@ public class RiotAccountManager {
     public RiotAccount renewAccount(String gameName, String tagLine) {
         RiotAccount fetchedAccount = riotAccountRepository
                 .findByGameNameAndTagLine(gameName, tagLine)
-                .orElseThrow(() -> new IllegalStateException("Account not found"));
+                .orElseThrow(() -> new RiotAccountNotFoundException(
+                        "GameName: " + gameName + ", TagLine: " + tagLine + " 에 해당하는 Riot 계정을 찾을 수 없습니다."));
 
         fetchedAccount.renewUpdatedAt();
         return fetchedAccount;

--- a/api/src/main/java/com/glennsyj/rivals/api/rivalry/controller/RivalryController.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/rivalry/controller/RivalryController.java
@@ -24,28 +24,18 @@ public class RivalryController {
     @PostMapping("")
     public ResponseEntity<?> createRivalry(@Valid @RequestBody RivalryCreationDto creationDto) {
 
-        try {
-            Long rivalryId = rivalryService.createRivalryFrom(creationDto);
-            RivalryResultDto response = new RivalryResultDto(rivalryId.toString());
+        Long rivalryId = rivalryService.createRivalryFrom(creationDto);
+        RivalryResultDto response = new RivalryResultDto(rivalryId.toString());
 
-            URI uri = URI.create("/api/v1/rivalries/" + rivalryId);
+        URI uri = URI.create("/api/v1/rivalries/" + rivalryId);
 
-            return ResponseEntity.created(uri).body(response);
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(e.getMessage());
-        } catch (IllegalStateException e) {
-            return ResponseEntity.notFound().build();
-        }
+        return ResponseEntity.created(uri).body(response);
     }
 
     @GetMapping("/{rivalryId}")
     public ResponseEntity<?> getRivalryById(@PathVariable String rivalryId) {
 
-        try {
-            RivalryDetailDto response = rivalryService.findRivalryFrom(Long.valueOf(rivalryId));
-            return ResponseEntity.ok(response);
-        } catch (EntityNotFoundException e) {
-            return ResponseEntity.notFound().build();
-        }
+        RivalryDetailDto response = rivalryService.findRivalryFrom(Long.valueOf(rivalryId));
+        return ResponseEntity.ok(response);
     }
 }

--- a/api/src/main/java/com/glennsyj/rivals/api/rivalry/service/RivalryService.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/rivalry/service/RivalryService.java
@@ -1,5 +1,6 @@
 package com.glennsyj.rivals.api.rivalry.service;
 
+import com.glennsyj.rivals.api.common.exception.RiotAccountNotFoundException;
 import com.glennsyj.rivals.api.riot.entity.RiotAccount;
 import com.glennsyj.rivals.api.riot.repository.RiotAccountRepository;
 import com.glennsyj.rivals.api.rivalry.entity.RivalSide;
@@ -44,7 +45,7 @@ public class RivalryService {
 
         // 중간 검증: account를 하나도 찾을 수 없을 시
         if (accounts.isEmpty()) {
-            throw new IllegalStateException("Some of accounts not found");
+            throw new RiotAccountNotFoundException("All of the accounts are not found");
         }
 
         HashMap<Long, RiotAccount> accountMap = new HashMap<>();
@@ -65,7 +66,7 @@ public class RivalryService {
         rivalry = rivalryRepository.save(rivalry);
         // 최종 검증: dto 내 participant 수와 영속화된 participant 수 비교
         if (accountIds.size() != rivalry.getParticipants().size()) {
-            throw new IllegalArgumentException("Some of accounts not found");
+            throw new RiotAccountNotFoundException("Some of accounts not found");
         }
 
         return rivalry.getId();

--- a/api/src/main/java/com/glennsyj/rivals/api/rivalry/service/RivalryService.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/rivalry/service/RivalryService.java
@@ -13,7 +13,7 @@ import com.glennsyj.rivals.api.rivalry.repository.RivalryRepository;
 import com.glennsyj.rivals.api.tft.entity.entry.TftLeagueEntry;
 import com.glennsyj.rivals.api.tft.model.entry.TftStatusDto;
 import com.glennsyj.rivals.api.tft.repository.TftLeagueEntryRepository;
-import jakarta.persistence.EntityNotFoundException;
+import com.glennsyj.rivals.api.common.exception.RivalryNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -75,7 +75,7 @@ public class RivalryService {
     public RivalryDetailDto findRivalryFrom(Long id) {
 
         // 1. Rivalry 정보 불러오고 캐시로 이용할 맵 초기화
-        Rivalry rivalry = rivalryRepository.findById(id).orElseThrow(EntityNotFoundException::new);
+        Rivalry rivalry = rivalryRepository.findById(id).orElseThrow(() -> new RivalryNotFoundException(id));
         Map<Long, String> nameCacheMap = new HashMap<>();
         Map<Long, TftStatusDto> leagueEntryCacheMap = new HashMap<>();
 

--- a/api/src/main/java/com/glennsyj/rivals/api/tft/controller/TftBadgeController.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/tft/controller/TftBadgeController.java
@@ -40,13 +40,9 @@ public class TftBadgeController {
     public ResponseEntity<List<TftBadgeDto>> initializeOrGetBadgesForSummoner(
             @PathVariable String gameName,
             @PathVariable String tagLine) {
-        try {
-            RiotAccount account = riotAccountManager.findOrRegisterAccount(gameName, tagLine);
-            List<TftBadgeDto> badges = tftBadgeService.findAllBadges(account);
-            return ResponseEntity.ok(badges);
-        } catch (IllegalStateException e) {
-            return ResponseEntity.badRequest().build();
-        }
+        RiotAccount account = riotAccountManager.findOrRegisterAccount(gameName, tagLine);
+        List<TftBadgeDto> badges = tftBadgeService.findAllBadges(account);
+        return ResponseEntity.ok(badges);
     }
 
     @GetMapping("/{gameName}/{tagLine}/{badgeType}")
@@ -54,27 +50,16 @@ public class TftBadgeController {
             @PathVariable String gameName,
             @PathVariable String tagLine,
             @PathVariable String badgeType) {
-        try {
-            RiotAccount account = riotAccountManager.findOrRegisterAccount(gameName, tagLine);
-            return tftBadgeService.findBadge(account, TftBadgeProgress.BadgeType.valueOf(badgeType))
-                .map(ResponseEntity::ok)
-                .orElse(ResponseEntity.notFound().build());
-        } catch (IllegalStateException | IllegalArgumentException e) {
-            log.error("Failed to find badge: {}", e.getMessage(), e);
-            return ResponseEntity.badRequest().build();
-        }
+        RiotAccount account = riotAccountManager.findOrRegisterAccount(gameName, tagLine);
+        return tftBadgeService.findBadge(account, TftBadgeProgress.BadgeType.valueOf(badgeType))
+            .map(ResponseEntity::ok)
+            .orElse(ResponseEntity.notFound().build());
     }
 
     @PostMapping("/bulk")
     public ResponseEntity<TftBadgeBulkResponseDto> findBadgeBulkWithPuuids(@RequestBody TftBadgeBulkRequestDto requestDto) {
 
-        try {
-            TftBadgeBulkResponseDto responseDto = tftBadgeService.findBadgesFromPuuids(requestDto.puuids());
-            return ResponseEntity.ok(responseDto);
-        } catch (Exception e) {
-            log.error("Failed to find badges: {}", e.getMessage(), e);
-            return ResponseEntity.badRequest().build();
-        }
-
+        TftBadgeBulkResponseDto responseDto = tftBadgeService.findBadgesFromPuuids(requestDto.puuids());
+        return ResponseEntity.ok(responseDto);
     }
 } 

--- a/api/src/main/java/com/glennsyj/rivals/api/tft/controller/TftLeagueEntryController.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/tft/controller/TftLeagueEntryController.java
@@ -35,43 +35,35 @@ public class TftLeagueEntryController {
         // '#' character는 PathVariable로 전달되지 않음.
         String[] parts = encodedFullName.split("#");
         if (parts.length != 2) {
-            return ResponseEntity.badRequest().body("Invalid format for encodedFullName: " + encodedFullName);
+            throw new IllegalArgumentException("Invalid format for encodedFullName: " + encodedFullName);
         }
 
         String gameName = parts[0];
         String tagLine = parts[1];
 
-        try {
-            RiotAccount account = riotAccountManager.findOrRegisterAccount(gameName, tagLine);
-            List<TftLeagueEntry> entries = tftLeagueEntryManager.findOrCreateLeagueEntries(account.getId());
+        RiotAccount account = riotAccountManager.findOrRegisterAccount(gameName, tagLine);
+        List<TftLeagueEntry> entries = tftLeagueEntryManager.findOrCreateLeagueEntries(account.getId());
 
-            List<TftStatusDto> dtos = new ArrayList<>(entries.size());
-            for (TftLeagueEntry entry : entries) {
-                TftStatusDto dto = TftStatusDto.from(entry);
-                dtos.add(dto);
-            }
-
-            return ResponseEntity.ok(dtos);
-        } catch (IllegalStateException e) {
-            return ResponseEntity.notFound().build();
+        List<TftStatusDto> dtos = new ArrayList<>(entries.size());
+        for (TftLeagueEntry entry : entries) {
+            TftStatusDto dto = TftStatusDto.from(entry);
+            dtos.add(dto);
         }
+
+        return ResponseEntity.ok(dtos);
     }
 
     @GetMapping(path="/{gameName}/{tagLine}")
     public ResponseEntity<?> getTftStatusFrom(@PathVariable String gameName, @PathVariable String tagLine) {
-        try {
-            RiotAccount account = riotAccountManager.findOrRegisterAccount(gameName, tagLine);
-            List<TftLeagueEntry> entries = tftLeagueEntryManager.findOrCreateLeagueEntries(account.getId());
+        RiotAccount account = riotAccountManager.findOrRegisterAccount(gameName, tagLine);
+        List<TftLeagueEntry> entries = tftLeagueEntryManager.findOrCreateLeagueEntries(account.getId());
 
-            List<TftStatusDto> dtos = new ArrayList<>(entries.size());
-            for (TftLeagueEntry entry : entries) {
-                TftStatusDto dto = TftStatusDto.from(entry);
-                dtos.add(dto);
-            }
-
-            return ResponseEntity.ok(dtos);
-        } catch (IllegalStateException e) {
-            return ResponseEntity.notFound().build();
+        List<TftStatusDto> dtos = new ArrayList<>(entries.size());
+        for (TftLeagueEntry entry : entries) {
+            TftStatusDto dto = TftStatusDto.from(entry);
+            dtos.add(dto);
         }
+
+        return ResponseEntity.ok(dtos);
     }
 }

--- a/api/src/main/java/com/glennsyj/rivals/api/tft/controller/TftMatchController.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/tft/controller/TftMatchController.java
@@ -21,11 +21,7 @@ public class TftMatchController {
     public ResponseEntity<List<TftRecentMatchDto>> getRecentMatches(
             @PathVariable String gameName,
             @PathVariable String tagLine) {
-        try {
-            List<TftRecentMatchDto> dtos = tftFacade.findAndProcessMatches(gameName, tagLine);
-            return ResponseEntity.ok(dtos);
-        } catch (IllegalStateException e) {
-            return ResponseEntity.badRequest().build();
-        }
+        List<TftRecentMatchDto> dtos = tftFacade.findAndProcessMatches(gameName, tagLine);
+        return ResponseEntity.ok(dtos);
     }
 }

--- a/api/src/main/java/com/glennsyj/rivals/api/tft/controller/TftRenewController.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/tft/controller/TftRenewController.java
@@ -26,12 +26,7 @@ public class TftRenewController {
             @PathVariable String gameName,
             @PathVariable String tagLine
     ) {
-        try {
-            TftRenewDto result = tftFacade.renewAllTftData(gameName, tagLine);
-            return ResponseEntity.ok(result);
-        } catch (TftRenewException e) {
-            log.error("Failed to renew TFT data for {}#{}", gameName, tagLine, e);
-            return ResponseEntity.internalServerError().build();
-        }
+        TftRenewDto result = tftFacade.renewAllTftData(gameName, tagLine);
+        return ResponseEntity.ok(result);
     }
 }

--- a/api/src/main/java/com/glennsyj/rivals/api/tft/service/TftLeagueEntryManager.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/tft/service/TftLeagueEntryManager.java
@@ -6,6 +6,7 @@ import com.glennsyj.rivals.api.tft.TftApiClient;
 import com.glennsyj.rivals.api.tft.entity.entry.TftLeagueEntry;
 import com.glennsyj.rivals.api.tft.model.entry.TftLeagueEntryResponse;
 import com.glennsyj.rivals.api.tft.repository.TftLeagueEntryRepository;
+import com.glennsyj.rivals.api.common.exception.RiotAccountNotFoundException;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
@@ -49,7 +50,7 @@ public class TftLeagueEntryManager {
         return tftLeagueEntryRepository.findFirstByAccount_IdOrderByUpdatedAtDesc(accountId)
             .orElseGet(() -> {
                 RiotAccount account = riotAccountRepository.findById(accountId)
-                    .orElseThrow(() -> new IllegalStateException("계정을 찾을 수 없습니다: " + accountId));
+                    .orElseThrow(() -> new RiotAccountNotFoundException(accountId));
 
                 List<TftLeagueEntryResponse> responses = tftApiClient.getLeagueEntries(account.getPuuid());
 
@@ -80,7 +81,7 @@ public class TftLeagueEntryManager {
             }
 
             RiotAccount account = riotAccountRepository.findById(accountId)
-                    .orElseThrow(() -> new IllegalStateException("계정을 찾을 수 없습니다: " + accountId));
+                    .orElseThrow(() -> new RiotAccountNotFoundException(accountId));
 
             List<TftLeagueEntryResponse> responses = tftApiClient.getLeagueEntries(account.getPuuid());
 
@@ -116,7 +117,7 @@ public class TftLeagueEntryManager {
             }
 
             RiotAccount account = riotAccountRepository.findById(accountId).orElseThrow(
-                    EntityNotFoundException::new
+                    () -> new RiotAccountNotFoundException(accountId)
             );
 
             List<TftLeagueEntry> entries = tftLeagueEntryRepository

--- a/api/src/main/java/com/glennsyj/rivals/api/tft/service/TftLeagueEntryManager.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/tft/service/TftLeagueEntryManager.java
@@ -1,5 +1,6 @@
 package com.glennsyj.rivals.api.tft.service;
 
+import com.glennsyj.rivals.api.common.exception.TftNoGameException;
 import com.glennsyj.rivals.api.riot.entity.RiotAccount;
 import com.glennsyj.rivals.api.riot.repository.RiotAccountRepository;
 import com.glennsyj.rivals.api.tft.TftApiClient;
@@ -55,7 +56,7 @@ public class TftLeagueEntryManager {
                 List<TftLeagueEntryResponse> responses = tftApiClient.getLeagueEntries(account.getPuuid());
 
                 if (responses.isEmpty()) {
-                    throw new IllegalStateException("이번 시즌 TFT 랭크 기록이 존재하지 않습니다");
+                    throw new TftNoGameException("이번 시즌 TFT 랭크 기록이 존재하지 않습니다");
                 }
 
                 TftLeagueEntryResponse response = responses.get(0);
@@ -113,7 +114,7 @@ public class TftLeagueEntryManager {
         try {
             List<TftLeagueEntryResponse> responses = tftApiClient.getLeagueEntries(puuid);
             if (responses.isEmpty()) {
-                throw new IllegalStateException("이번 시즌 TFT 랭크 기록이 존재하지 않습니다");
+                throw new TftNoGameException("이번 시즌 TFT 랭크 기록이 존재하지 않습니다.");
             }
 
             RiotAccount account = riotAccountRepository.findById(accountId).orElseThrow(


### PR DESCRIPTION
# API 에러 처리 로직 개선 및 커스텀 예외 도입

## 개요

컨트롤러 계층에서 반복되던 로컬 예외 처리 로직을 제거하고, 전역 예외 핸들러(`GlobalExceptionHandler`)를 통해 일관적이고 중앙화된 방식으로 예외를 처리하도록 리팩토링했습니다. 이를 위해 Riot API 관련 오류 및 서비스 계층에서 발생하는 특정 비즈니스 예외를 위한 커스텀 예외 클래스들을 새롭게 정의하고 적용하여 예외 처리의 명확성과 확장성을 높였습니다.

## 주요 변경사항

### 1.  커스텀 예외 클래스 추가 및 구조화

  -   `api/src/main/java/com/glennsyj/rivals/api/common/exception/` 경로에 다음 커스텀 예외 클래스들을 추가했습니다:
      -   `CustomException`: 모든 커스텀 비즈니스 예외의 기반 클래스로, `ErrorResponseException`을 상속하여 Spring의 ProblemDetail 표준을 따르도록 설계되었습니다.
      -   `RiotAccountNotFoundException`: Riot 계정을 찾을 수 없을 때 발생합니다.
      -   `RiotApiException`: Riot API 호출 중 발생하는 일반적인 오류나 비율 제한(Rate Limit) 초과 시 발생합니다.
      -   `RivalryNotFoundException`: 라이벌리 정보를 찾을 수 없을 때 발생합니다.
      -   `TftNoGameException`: 해당 시즌에 TFT 랭크 게임 기록이 없는 계정에 대해 발생합니다.
  -  서비스 클래스에 위 예외를 적용했습니다.
 
### 2.  `GlobalExceptionHandler` 구현

  -   `api/src/main/java/com/glennsyj/rivals/api/common/exception/GlobalExceptionHandler.java`에 새로 정의된 `CustomException`을 처리하는 전역 핸들러를 추가했습니다. 이로써 모든 커스텀 예외에 대해 일관된 HTTP 응답(ProblemDetail) 및 로깅이 가능해졌습니다.
  - `MethodArgumentNotValidException`, `NoSuchElementException`, `HttpMessageNotReadableException`, `IllegalArgumentException`, `Exception` 핸들러 작성.

### 3.  컨트롤러 계층의 try-catch 제거

  -  컨트롤러 내부에 존재하던 예외 처리 `try-catch` 블록들을 모두 제거했습니다.
  -  이제 컨트롤러는 예외를 직접 처리하지 않고, 서비스 계층에서 발생한 커스텀 예외가 `GlobalExceptionHandler`로 자동 전파되어 처리됩니다.
  - `TftLeagueEntryController.java`에서는 유효하지 않은 `encodedFullName` 형식에 대해 `IllegalArgumentException`을 직접 던지도록 변경했습니다.


## 관련 이슈
Fixes #38