### PR TITLE
 프론트엔드 에러 처리 연동 및 백엔드 API 문서화 개선

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -26,6 +26,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-webflux")
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.springframework.boot:spring-boot-starter-actuator")
+	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9")
 
 	implementation("io.hypersistence:hypersistence-utils-hibernate-63:3.7.3")
 	testImplementation("org.testcontainers:testcontainers:1.19.7")

--- a/api/src/main/java/com/glennsyj/rivals/api/common/client/BaseRiotClient.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/common/client/BaseRiotClient.java
@@ -48,9 +48,15 @@ public abstract class BaseRiotClient {
                     "Riot API 호출 횟수 제한 초과. " + retryAfter + "초 후에 다시 시도해주세요.",
                     e.getStatusCode().value()
                 );
+            } else if (e.getStatusCode() == HttpStatus.NOT_FOUND) {
+                throw new RiotApiException(
+                        HttpStatus.NOT_FOUND,
+                        errorMessage,
+                        e.getStatusCode().value()
+                );
             }
             throw new RiotApiException(
-                "Riot API 호출 실패: " + e.getResponseBodyAsString(),
+                "Riot API 호출 실패: " + errorMessage,
                 e.getStatusCode().value()
             );
         } finally {

--- a/api/src/main/java/com/glennsyj/rivals/api/common/config/OpenApiConfig.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/common/config/OpenApiConfig.java
@@ -1,0 +1,19 @@
+package com.glennsyj.rivals.api.common.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.servers.Server;
+import org.springframework.context.annotation.Configuration;
+
+@OpenAPIDefinition(
+    info = @Info(title = "Rivals API",
+            description = "API documentation for the Rivals application",
+            version = "v1"),
+    servers = {
+        @Server(url = "http://localhost:8080", description = "Local Server")
+    }
+)
+@Configuration
+public class OpenApiConfig {
+    // Prod 환경에서는 설정 yml 파일을 통해 비활성화함
+} 

--- a/api/src/main/java/com/glennsyj/rivals/api/common/exception/RiotApiException.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/common/exception/RiotApiException.java
@@ -17,4 +17,11 @@ public class RiotApiException extends CustomException {
             getBody().setProperty("riotApiStatusCode", riotApiStatusCode);
         }
     }
+
+    public RiotApiException(HttpStatus status, String message, Integer riotApiStatusCode) {
+        super(status, TITLE, message, null);
+        if (riotApiStatusCode != null) {
+            getBody().setProperty("riotApiStatusCode", riotApiStatusCode);
+        }
+    }
 } 

--- a/api/src/main/java/com/glennsyj/rivals/api/riot/controller/RiotController.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/riot/controller/RiotController.java
@@ -10,7 +10,11 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
+@Tag(name = "Riot API", description = "Riot 계정과 관련된 작업")
 @RestController
 @RequestMapping("/api/v1/riot")
 public class RiotController {
@@ -23,6 +27,13 @@ public class RiotController {
         this.riotAccountManager = riotAccountManager;
     }
 
+    @Operation(summary = "Riot 계정 찾기 또는 등록",
+            description = "기존 Riot 계정을 검색하거나, 없는 경우 새로 등록합니다.",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "계정 성공적으로 찾음 또는 등록됨"),
+                @ApiResponse(responseCode = "404", description = "Riot 계정을 찾을 수 없음"),
+                @ApiResponse(responseCode = "500", description = "내부 서버 오류")
+            })
     @GetMapping("/accounts/{gameName}/{tagLine}")
     public ResponseEntity<RiotAccountDto> findAccount(@PathVariable("gameName") String gameName
             , @PathVariable("tagLine") String tagLine) {
@@ -30,6 +41,13 @@ public class RiotController {
         return ResponseEntity.ok(RiotAccountDto.from(account));
     }
 
+    @Operation(summary = "Riot 계정 갱신",
+            description = "기존 Riot 계정 정보를 갱신합니다.",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "계정 성공적으로 갱신됨"),
+                @ApiResponse(responseCode = "404", description = "Riot 계정을 찾을 수 없음"),
+                @ApiResponse(responseCode = "500", description = "내부 서버 오류")
+            })
     @PatchMapping("/accounts/renew/{gameName}/{tagLine}")
     public ResponseEntity<RiotAccountDto> renewAccount(@PathVariable("gameName") String gameName
             , @PathVariable("tagLine") String tagLine) {

--- a/api/src/main/java/com/glennsyj/rivals/api/riot/model/RiotAccountDto.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/riot/model/RiotAccountDto.java
@@ -2,12 +2,19 @@ package com.glennsyj.rivals.api.riot.model;
 
 import com.glennsyj.rivals.api.riot.entity.RiotAccount;
 import java.time.LocalDateTime;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "Riot 계정 응답 DTO")
 public record RiotAccountDto(
+        @Schema(description = "Riot PUUID")
         String puuid,
+        @Schema(description = "게임 내 이름")
         String gameName,
+        @Schema(description = "태그 라인")
         String tagLine,
+        @Schema(description = "계정 ID")
         String id,
+        @Schema(description = "마지막 업데이트 시간")
         LocalDateTime updatedAt
 ) {
     public static RiotAccountDto from(RiotAccount account) {

--- a/api/src/main/java/com/glennsyj/rivals/api/rivalry/controller/RivalryController.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/rivalry/controller/RivalryController.java
@@ -8,9 +8,13 @@ import jakarta.persistence.EntityNotFoundException;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.net.URI;
 
+@Tag(name = "라이벌리 API", description = "라이벌리와 관련된 작업")
 @RestController
 @RequestMapping("/api/v1/rivalries")
 public class RivalryController {
@@ -21,6 +25,13 @@ public class RivalryController {
         this.rivalryService = rivalryService;
     }
 
+    @Operation(summary = "새로운 라이벌리 생성",
+            description = "여러 Riot 계정 간에 새로운 라이벌리를 생성합니다.",
+            responses = {
+                @ApiResponse(responseCode = "201", description = "라이벌리 성공적으로 생성됨"),
+                @ApiResponse(responseCode = "400", description = "잘못된 요청 본문"),
+                @ApiResponse(responseCode = "500", description = "내부 서버 오류")
+            })
     @PostMapping("")
     public ResponseEntity<?> createRivalry(@Valid @RequestBody RivalryCreationDto creationDto) {
 
@@ -32,6 +43,13 @@ public class RivalryController {
         return ResponseEntity.created(uri).body(response);
     }
 
+    @Operation(summary = "ID로 라이벌리 조회",
+            description = "ID를 통해 특정 라이벌리의 상세 정보를 검색합니다.",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "라이벌리 상세 정보 성공적으로 검색됨"),
+                @ApiResponse(responseCode = "404", description = "라이벌리를 찾을 수 없음"),
+                @ApiResponse(responseCode = "500", description = "내부 서버 오류")
+            })
     @GetMapping("/{rivalryId}")
     public ResponseEntity<?> getRivalryById(@PathVariable String rivalryId) {
 

--- a/api/src/main/java/com/glennsyj/rivals/api/rivalry/model/RivalryCreationDto.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/rivalry/model/RivalryCreationDto.java
@@ -2,10 +2,13 @@ package com.glennsyj.rivals.api.rivalry.model;
 
 import com.glennsyj.rivals.api.rivalry.entity.RivalSide;
 import jakarta.validation.constraints.NotEmpty;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
+@Schema(description = "새로운 라이벌리 생성을 위한 요청 DTO")
 public record RivalryCreationDto(
+        @Schema(description = "라이벌리 참여자 목록")
         @NotEmpty(message="participants should not be empty")
         List<RivalryParticipantDto> participants
 ) {

--- a/api/src/main/java/com/glennsyj/rivals/api/rivalry/model/RivalryDetailDto.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/rivalry/model/RivalryDetailDto.java
@@ -2,11 +2,17 @@ package com.glennsyj.rivals.api.rivalry.model;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "라이벌리 상세 정보 DTO")
 public record RivalryDetailDto(
+        @Schema(description = "라이벌리 ID")
         String rivalryId,
+        @Schema(description = "LEFT 팀 참가자 통계 목록")
         List<ParticipantStatDto> leftStats,
+        @Schema(description = "RIGHT 팀 참가자 통계 목록")
         List<ParticipantStatDto> rightStats,
+        @Schema(description = "라이벌리 생성 시간")
         LocalDateTime createdAt
 ) {
 }

--- a/api/src/main/java/com/glennsyj/rivals/api/rivalry/model/RivalryParticipantDto.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/rivalry/model/RivalryParticipantDto.java
@@ -2,10 +2,14 @@ package com.glennsyj.rivals.api.rivalry.model;
 
 import com.glennsyj.rivals.api.rivalry.entity.RivalryParticipant;
 import com.glennsyj.rivals.api.rivalry.entity.RivalSide;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 
+@Schema(description = "라이벌리 참가자 정보 DTO")
 public record RivalryParticipantDto(
+    @Schema(description = "참가자 Riot 계정 ID")
     String id,
+    @Schema(description = "참가자 사이드 (LEFT 또는 RIGHT)")
     RivalSide side) {
 
     public static RivalryParticipantDto from(RivalryParticipant participant) {

--- a/api/src/main/java/com/glennsyj/rivals/api/tft/controller/TftBadgeController.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/tft/controller/TftBadgeController.java
@@ -11,9 +11,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.List;
 
+@Tag(name = "TFT 뱃지 API", description = "TFT 뱃지 및 업적과 관련된 작업")
 @RestController
 @RequestMapping("/api/v1/tft/badges")
 public class TftBadgeController {
@@ -28,6 +32,13 @@ public class TftBadgeController {
         this.riotAccountManager = riotAccountManager;
     }
 
+    @Operation(summary = "소환사의 모든 TFT 뱃지 조회",
+            description = "주어진 게임명과 태그라인에 대한 모든 TFT 뱃지 및 진행 상황을 검색합니다.",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "뱃지 성공적으로 검색됨"),
+                @ApiResponse(responseCode = "404", description = "Riot 계정을 찾을 수 없음"),
+                @ApiResponse(responseCode = "500", description = "내부 서버 오류")
+            })
     @GetMapping("/{gameName}/{tagLine}")
     public ResponseEntity<List<TftBadgeDto>> findAllBadges(
             @PathVariable String gameName,
@@ -36,6 +47,13 @@ public class TftBadgeController {
         return ResponseEntity.ok(badges);
     }
 
+    @Operation(summary = "소환사의 TFT 뱃지 초기화 또는 조회",
+            description = "소환사의 뱃지가 존재하지 않으면 초기화하고, 존재하면 뱃지를 검색합니다.",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "뱃지 성공적으로 초기화 또는 검색됨"),
+                @ApiResponse(responseCode = "404", description = "Riot 계정을 찾을 수 없음"),
+                @ApiResponse(responseCode = "500", description = "내부 서버 오류")
+            })
     @GetMapping("/{gameName}/{tagLine}/initialize")
     public ResponseEntity<List<TftBadgeDto>> initializeOrGetBadgesForSummoner(
             @PathVariable String gameName,
@@ -45,6 +63,13 @@ public class TftBadgeController {
         return ResponseEntity.ok(badges);
     }
 
+    @Operation(summary = "특정 TFT 뱃지 조회",
+            description = "게임명, 태그라인, 뱃지 유형으로 특정 TFT 뱃지를 검색합니다.",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "뱃지 성공적으로 검색됨"),
+                @ApiResponse(responseCode = "404", description = "Riot 계정 또는 뱃지를 찾을 수 없음"),
+                @ApiResponse(responseCode = "500", description = "내부 서버 오류")
+            })
     @GetMapping("/{gameName}/{tagLine}/{badgeType}")
     public ResponseEntity<TftBadgeDto> findBadge(
             @PathVariable String gameName,
@@ -56,6 +81,12 @@ public class TftBadgeController {
             .orElse(ResponseEntity.notFound().build());
     }
 
+    @Operation(summary = "PUUID로 TFT 뱃지 대량 조회",
+            description = "여러 소환사의 PUUID를 기반으로 TFT 뱃지를 검색합니다.",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "PUUID에 대한 뱃지 성공적으로 검색됨"),
+                @ApiResponse(responseCode = "500", description = "내부 서버 오류")
+            })
     @PostMapping("/bulk")
     public ResponseEntity<TftBadgeBulkResponseDto> findBadgeBulkWithPuuids(@RequestBody TftBadgeBulkRequestDto requestDto) {
 

--- a/api/src/main/java/com/glennsyj/rivals/api/tft/controller/TftLeagueEntryController.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/tft/controller/TftLeagueEntryController.java
@@ -12,10 +12,14 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.ArrayList;
 import java.util.List;
 
+@Tag(name = "TFT 리그 엔트리 API", description = "TFT 리그 엔트리와 관련된 작업")
 @RestController
 @RequestMapping(path="/api/v1/tft/entries")
 public class TftLeagueEntryController {
@@ -30,6 +34,14 @@ public class TftLeagueEntryController {
         this.riotAccountManager = riotAccountManager;
     }
 
+    @Operation(summary = "인코딩된 전체 이름으로 TFT 리그 상태 조회",
+            description = "주어진 인코딩된 전체 이름(게임명#태그라인)에 대한 TFT 리그 엔트리 상태를 검색합니다.",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "TFT 리그 엔트리 성공적으로 검색됨"),
+                @ApiResponse(responseCode = "400", description = "잘못된 인코딩된 전체 이름 형식"),
+                @ApiResponse(responseCode = "404", description = "Riot 계정 또는 TFT 리그 엔트리를 찾을 수 없음"),
+                @ApiResponse(responseCode = "500", description = "내부 서버 오류")
+            })
     @GetMapping(path="/{encodedFullName}")
     public ResponseEntity<?> getTftStatusFromFullName(@PathVariable String encodedFullName) {
         // '#' character는 PathVariable로 전달되지 않음.
@@ -53,6 +65,13 @@ public class TftLeagueEntryController {
         return ResponseEntity.ok(dtos);
     }
 
+    @Operation(summary = "게임명 및 태그라인으로 TFT 리그 상태 조회",
+            description = "주어진 게임명과 태그라인에 대한 TFT 리그 엔트리 상태를 검색합니다.",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "TFT 리그 엔트리 성공적으로 검색됨"),
+                @ApiResponse(responseCode = "404", description = "Riot 계정 또는 TFT 리그 엔트리를 찾을 수 없음"),
+                @ApiResponse(responseCode = "500", description = "내부 서버 오류")
+            })
     @GetMapping(path="/{gameName}/{tagLine}")
     public ResponseEntity<?> getTftStatusFrom(@PathVariable String gameName, @PathVariable String tagLine) {
         RiotAccount account = riotAccountManager.findOrRegisterAccount(gameName, tagLine);

--- a/api/src/main/java/com/glennsyj/rivals/api/tft/controller/TftMatchController.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/tft/controller/TftMatchController.java
@@ -5,9 +5,13 @@ import com.glennsyj.rivals.api.tft.model.match.TftRecentMatchDto;
 import org.apache.coyote.Response;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.List;
 
+@Tag(name = "TFT 매치 API", description = "TFT 매치와 관련된 작업")
 @RestController
 @RequestMapping("/api/v1/tft/matches")
 public class TftMatchController {
@@ -17,6 +21,13 @@ public class TftMatchController {
         this.tftFacade = tftFacade;
     }
 
+    @Operation(summary = "최근 TFT 매치 조회",
+            description = "주어진 게임명과 태그라인에 대한 최근 TFT 매치 목록을 검색합니다.",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "최근 매치 성공적으로 검색됨"),
+                @ApiResponse(responseCode = "404", description = "Riot 계정 또는 매치를 찾을 수 없음"),
+                @ApiResponse(responseCode = "500", description = "내부 서버 오류")
+            })
     @GetMapping("/{gameName}/{tagLine}")
     public ResponseEntity<List<TftRecentMatchDto>> getRecentMatches(
             @PathVariable String gameName,

--- a/api/src/main/java/com/glennsyj/rivals/api/tft/controller/TftRenewController.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/tft/controller/TftRenewController.java
@@ -10,7 +10,11 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 
+@Tag(name = "TFT 갱신 API", description = "TFT 데이터 갱신과 관련된 작업")
 @RestController
 @RequestMapping("/api/v1/tft/renew")
 public class TftRenewController {
@@ -21,6 +25,13 @@ public class TftRenewController {
         this.tftFacade = tftFacade;
     }
 
+    @Operation(summary = "모든 TFT 데이터 갱신",
+            description = "주어진 게임명과 태그라인에 대한 모든 TFT 관련 데이터(예: 리그 엔트리, 매치)를 갱신합니다.",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "모든 TFT 데이터 성공적으로 갱신됨"),
+                @ApiResponse(responseCode = "404", description = "Riot 계정 혹은 다른 Riot 리소스를 찾을 수 없음"),
+                @ApiResponse(responseCode = "500", description = "내부 서버 오류 또는 TFT 갱신 실패")
+            })
     @GetMapping("/{gameName}/{tagLine}")
     public ResponseEntity<TftRenewDto> renewAll(
             @PathVariable String gameName,

--- a/api/src/main/java/com/glennsyj/rivals/api/tft/model/badge/TftBadgeBulkRequestDto.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/tft/model/badge/TftBadgeBulkRequestDto.java
@@ -2,8 +2,11 @@ package com.glennsyj.rivals.api.tft.model.badge;
 
 import jakarta.validation.constraints.NotEmpty;
 import java.util.List;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "TFT 뱃지 대량 요청 DTO")
 public record TftBadgeBulkRequestDto(
+    @Schema(description = "PUUID 목록")
     @NotEmpty(message = "PUUIDs cannot be empty")
     List<String> puuids
 ) {

--- a/api/src/main/java/com/glennsyj/rivals/api/tft/model/badge/TftBadgeBulkResponseDto.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/tft/model/badge/TftBadgeBulkResponseDto.java
@@ -2,8 +2,11 @@ package com.glennsyj.rivals.api.tft.model.badge;
 
 import java.util.List;
 import java.util.Map;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "TFT 뱃지 대량 응답 DTO")
 public record TftBadgeBulkResponseDto(
+        @Schema(description = "PUUID별 뱃지 목록")
         Map<String, List<TftBadgeDto>> badgesOnPuuid
 ) {
 }

--- a/api/src/main/java/com/glennsyj/rivals/api/tft/model/badge/TftBadgeDto.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/tft/model/badge/TftBadgeDto.java
@@ -1,12 +1,19 @@
 package com.glennsyj.rivals.api.tft.model.badge;
 
 import com.glennsyj.rivals.api.tft.entity.achievement.TftBadgeProgress;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "TFT 뱃지 정보 DTO")
 public record TftBadgeDto(
+    @Schema(description = "뱃지 유형")
     String badgeType,
+    @Schema(description = "업적 유형")
     String achievementType,
+    @Schema(description = "현재 진행도")
     int currentCount,
+    @Schema(description = "필요 진행도")
     int requiredCount,
+    @Schema(description = "활성화 여부")
     boolean isActive
 ) {
     public static TftBadgeDto from(TftBadgeProgress progress) {

--- a/api/src/main/java/com/glennsyj/rivals/api/tft/model/entry/TftStatusDto.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/tft/model/entry/TftStatusDto.java
@@ -1,17 +1,26 @@
 package com.glennsyj.rivals.api.tft.model.entry;
 
 import com.glennsyj.rivals.api.tft.entity.entry.TftLeagueEntry;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
  * TFT 상태 정보 DTO
  */
+@Schema(description = "TFT 리그 엔트리 상태 정보 DTO")
 public record TftStatusDto(
+        @Schema(description = "큐 타입 (예: RANKED_TFT_TURBO)")
         String queueType,         // 큐 타입 (Enum QueueType)
+        @Schema(description = "티어 (예: DIAMOND)")
         String tier,              // 티어 (e.g. DIAMOND)
+        @Schema(description = "랭크 (예: I, II, III, IV)")
         String rank,              // 랭크 (e.g. I, II, III, IV)
+        @Schema(description = "리그 포인트 (LP)")
         int leaguePoints,         // LP
-        int wins,                 // 1등 횟수
-        int losses,               // 2-8등 횟수
+        @Schema(description = "1-4등 횟수")
+        int wins,                 // 1-4등 횟수
+        @Schema(description = "5-8등 횟수")
+        int losses,               // 5-8등 횟수
+        @Schema(description = "연승 여부")
         boolean hotStreak         // 연승 여부
 ) {
 

--- a/api/src/main/java/com/glennsyj/rivals/api/tft/model/match/TftMatchParticipantDto.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/tft/model/match/TftMatchParticipantDto.java
@@ -3,15 +3,25 @@ package com.glennsyj.rivals.api.tft.model.match;
 import com.glennsyj.rivals.api.tft.entity.match.TftMatchParticipant;
 
 import java.util.List;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "TFT 매치 참가자 정보 DTO")
 public record TftMatchParticipantDto(
+    @Schema(description = "Riot PUUID")
     String puuid,
+    @Schema(description = "플레이어 레벨")
     Integer level,
+    @Schema(description = "플레이어 최종 순위")
     Integer placement,
+    @Schema(description = "플레이어에게 가한 총 피해량")
     Integer totalDamageToPlayers,
+    @Schema(description = "Riot ID 게임 이름")
     String riotIdGameName,
+    @Schema(description = "Riot ID 태그라인")
     String riotIdTagline,
+    @Schema(description = "특성 목록")
     List<TftMatchTrait> traits,
+    @Schema(description = "유닛 목록")
     List<TftMatchUnit> units
 ) {
     public static TftMatchParticipantDto from(TftMatchParticipant participant) {

--- a/api/src/main/java/com/glennsyj/rivals/api/tft/model/match/TftMatchTrait.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/tft/model/match/TftMatchTrait.java
@@ -1,9 +1,17 @@
 package com.glennsyj.rivals.api.tft.model.match;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "TFT 매치 특성 정보 DTO")
 public record TftMatchTrait(
+        @Schema(description = "특성 이름")
         String name,
+        @Schema(description = "특성 유닛 수")
         Integer num_units,
+        @Schema(description = "특성 스타일")
         Integer style,
+        @Schema(description = "현재 특성 티어")
         Integer tier_current,
+        @Schema(description = "총 특성 티어")
         Integer tier_total
 ) {}

--- a/api/src/main/java/com/glennsyj/rivals/api/tft/model/match/TftMatchUnit.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/tft/model/match/TftMatchUnit.java
@@ -1,11 +1,18 @@
 package com.glennsyj.rivals.api.tft.model.match;
 
 import java.util.List;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "TFT 매치 유닛 정보 DTO")
 public record TftMatchUnit(
+        @Schema(description = "캐릭터 ID")
         String character_id,
+        @Schema(description = "아이템 이름 목록")
         List<String> itemNames,
+        @Schema(description = "유닛 이름")
         String name,
+        @Schema(description = "유닛 희귀도")
         Integer rarity,
+        @Schema(description = "유닛 티어")
         Integer tier
 ) {}

--- a/api/src/main/java/com/glennsyj/rivals/api/tft/model/match/TftRecentMatchDto.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/tft/model/match/TftRecentMatchDto.java
@@ -4,20 +4,32 @@ import com.glennsyj.rivals.api.tft.entity.match.TftMatch;
 import com.glennsyj.rivals.api.tft.entity.match.TftMatchParticipant;
 
 import java.util.List;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 /*
     특정 계정의 전적 전시에 이용될 DTO
  */
+@Schema(description = "최근 TFT 매치 정보 DTO")
 public record TftRecentMatchDto(
+    @Schema(description = "매치 ID (내부)")
     String id,
+    @Schema(description = "Riot API 매치 ID")
     String matchId,
+    @Schema(description = "게임 생성 시간 (에포크 시간)")
     Long gameCreation,
+    @Schema(description = "게임 길이 (초)")
     Double gameLength,
+    @Schema(description = "플레이어 레벨")
     Integer level,
+    @Schema(description = "플레이어 최종 순위")
     Integer placement,
+    @Schema(description = "큐 타입 (예: RANKED_TFT_TURBO)")
     String queueType,
+    @Schema(description = "특성 목록")
     List<TftMatchTrait> traits,
+    @Schema(description = "유닛 목록")
     List<TftMatchUnit> units,
+    @Schema(description = "참가자 목록")
     List<TftMatchParticipantDto> participants
 ) {
     public static TftRecentMatchDto from(String puuid, TftMatch match) {

--- a/api/src/main/java/com/glennsyj/rivals/api/tft/model/renew/TftRenewDto.java
+++ b/api/src/main/java/com/glennsyj/rivals/api/tft/model/renew/TftRenewDto.java
@@ -6,10 +6,16 @@ import com.glennsyj.rivals.api.tft.model.match.TftRecentMatchDto;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "TFT 데이터 갱신 응답 DTO")
 public record TftRenewDto(
+    @Schema(description = "갱신된 TFT 리그 엔트리 상태 목록")
     List<TftStatusDto> statuses,
+    @Schema(description = "갱신된 최근 TFT 매치 목록")
     List<TftRecentMatchDto> matches,
+    @Schema(description = "갱신된 TFT 배지 목록")
     List<TftBadgeDto> badges,
+    @Schema(description = "갱신 시간")
     LocalDateTime renewedAt
 ) { }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       next:
         specifier: 15.3.2
         version: 15.3.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next-themes:
+        specifier: ^0.4.6
+        version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       postcss:
         specifier: ^8.5.3
         version: 8.5.3
@@ -41,6 +44,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.1.0(react@19.1.0)
+      sonner:
+        specifier: ^2.0.6
+        version: 2.0.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       tailwind-merge:
         specifier: ^3.3.0
         version: 3.3.0
@@ -1698,6 +1704,12 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  next-themes@0.4.6:
+    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
+    peerDependencies:
+      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+
   next@15.3.2:
     resolution: {integrity: sha512-CA3BatMyHkxZ48sgOCLdVHjFU36N7TF1HhqAHLFOkV6buwZnvMI84Cug8xD56B9mCuKrqXnLn94417GrZ/jjCQ==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
@@ -1931,6 +1943,12 @@ packages:
 
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
+
+  sonner@2.0.6:
+    resolution: {integrity: sha512-yHFhk8T/DK3YxjFQXIrcHT1rGEeTLliVzWbO0xN8GberVun2RiBnxAjXAYpZrqwEVHBG9asI/Li8TAAhN9m59Q==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -3782,6 +3800,11 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  next-themes@0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
   next@15.3.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@next/env': 15.3.2
@@ -4081,6 +4104,11 @@ snapshots:
     dependencies:
       is-arrayish: 0.3.2
     optional: true
+
+  sonner@2.0.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   source-map-js@1.2.1: {}
 

--- a/web/package.json
+++ b/web/package.json
@@ -17,9 +17,11 @@
     "clsx": "^2.1.1",
     "lucide-react": "^0.511.0",
     "next": "15.3.2",
+    "next-themes": "^0.4.6",
     "postcss": "^8.5.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "sonner": "^2.0.6",
     "tailwind-merge": "^3.3.0",
     "zustand": "^5.0.6"
   },

--- a/web/src/app/(features)/summoner/[encodedName]/_components/SummonerHeader.tsx
+++ b/web/src/app/(features)/summoner/[encodedName]/_components/SummonerHeader.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
 import { ArrowLeft, ShoppingCart, Search, Sword } from "lucide-react";
+import { findRiotAccount } from "@/lib/api";
 
 export function SummonerHeader() {
   const router = useRouter();
@@ -26,7 +27,13 @@ export function SummonerHeader() {
 
     const searchKey = searchInput.trim();
     if (searchKey) {
-      router.push(`/summoner/${encodeURIComponent(searchInput.trim())}`);
+      const [gameName, tagLine] = parts;
+      const accountData = await findRiotAccount(gameName, tagLine);
+      if (accountData) {
+        router.push(`/summoner/${encodeURIComponent(searchInput.trim())}`);
+      } else {
+        setSearchError("소환사를 찾을 수 없습니다");
+      }
     } else {
       setSearchError("소환사를 찾을 수 없습니다");
     }

--- a/web/src/app/(features)/summoner/[encodedName]/page.tsx
+++ b/web/src/app/(features)/summoner/[encodedName]/page.tsx
@@ -64,7 +64,6 @@ export default function SummonerPage() {
     setIsInitialRefreshPending,
   } = useSummonerPageLoadStore();
 
-  const [error, setError] = useState<string | null>(null);
   const [account, setAccount] = useState<RiotAccountDto | null>(null);
   const [selectedQueueType, setSelectedQueueType] =
     useState<string>("RANKED_TFT");
@@ -96,9 +95,6 @@ export default function SummonerPage() {
         setAccountStatus("success");
       } catch (error) {
         console.error("Error fetching account data:", error);
-        setError(
-          error instanceof Error ? error.message : "Failed to load account data"
-        );
         setAccountStatus("error");
       }
     };
@@ -127,7 +123,7 @@ export default function SummonerPage() {
           setAccount(renewedAccount);
         } catch (e) {
           console.error("Failed to refresh account on initial load", e);
-          setError("Failed to refresh account on initial load");
+          setAccountStatus("error");
         } finally {
           setIsRefreshing(false);
           setIsInitialRefreshPending(false);
@@ -179,17 +175,18 @@ export default function SummonerPage() {
     );
   }
 
-  if (error) {
+  if (accountStatus === "error" && !account) {
     return (
       <div className="min-h-screen bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900 flex items-center justify-center">
         <div className="text-center max-w-md">
           <Card className="bg-red-900/20 border-red-700/50">
             <CardHeader>
               <CardTitle className="text-red-400 flex items-center justify-center">
-                오류 발생
+                소환사를 찾을 수 없습니다
               </CardTitle>
               <CardDescription className="text-red-300">
-                {error}
+                요청하신 소환사 정보를 찾을 수 없습니다. 이름과 태그를
+                확인해주세요.
               </CardDescription>
               <Button
                 onClick={() => router.push("/")}
@@ -207,7 +204,7 @@ export default function SummonerPage() {
   }
 
   if (!account) {
-    return null; // Should be handled by isLoading or error state
+    return null; // Should ideally not be reached if accountStatus is handled correctly, but as a fallback
   }
 
   return (

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -4,6 +4,8 @@ import { Inter } from "next/font/google";
 import "./globals.css";
 import RivalryCart from "@/components/RivalryCart";
 import { dataDragonService } from "@/lib/dataDragon";
+import { Toaster } from "@/components/ui/sonner"; // sonner의 Toaster 컴포넌트 임포트
+import { ErrorToastDisplay } from "@/components/ErrorToastDisplay"; // ErrorToastDisplay 컴포넌트 임포트
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -25,6 +27,9 @@ export default function RootLayout({
       <body className={inter.className}>
         {children}
         <RivalryCart />
+        <Toaster /> {/* 전역 토스트 메시지를 표시할 Toaster 컴포넌트 추가 */}
+        <ErrorToastDisplay />{" "}
+        {/* 에러 발생 시 토스트를 트리거할 컴포넌트 추가 */}
       </body>
     </html>
   );

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -52,8 +52,10 @@ export default function Component() {
 
     try {
       const [gameName, tagLine] = parts;
-      await findRiotAccount(gameName, tagLine);
-      router.push(`/summoner/${encodeURIComponent(searchInput.trim())}`);
+      const accountData = await findRiotAccount(gameName, tagLine);
+      if (accountData) {
+        router.push(`/summoner/${encodeURIComponent(searchInput.trim())}`);
+      }
     } catch (err) {
       setError("소환사를 찾을 수 없습니다");
     }

--- a/web/src/components/ErrorToastDisplay.tsx
+++ b/web/src/components/ErrorToastDisplay.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import React, { useEffect } from "react";
+import { toast } from "sonner"; // sonner 라이브러리의 toast 함수를 직접 임포트
+import { useErrorStore } from "@/store/errorStore";
+
+export function ErrorToastDisplay() {
+  const { error, setError } = useErrorStore();
+
+  useEffect(() => {
+    if (error) {
+      toast.error(`Error: ${error.status || "Unknown"}`, {
+        description: error.message,
+        // sonner는 variant 대신 type이나 style 등으로 메시지 형태를 제어합니다.
+        // 여기서는 기본적으로 error 타입으로 표시합니다.
+      });
+      // 에러 메시지를 표시한 후 상태 초기화
+      setError(null);
+    }
+  }, [error, setError]);
+
+  return null; // 이 컴포넌트는 UI를 직접 렌더링하지 않고 토스트만 관리합니다.
+}

--- a/web/src/components/ui/sonner.tsx
+++ b/web/src/components/ui/sonner.tsx
@@ -1,0 +1,25 @@
+"use client"
+
+import { useTheme } from "next-themes"
+import { Toaster as Sonner, ToasterProps } from "sonner"
+
+const Toaster = ({ ...props }: ToasterProps) => {
+  const { theme = "system" } = useTheme()
+
+  return (
+    <Sonner
+      theme={theme as ToasterProps["theme"]}
+      className="toaster group"
+      style={
+        {
+          "--normal-bg": "var(--popover)",
+          "--normal-text": "var(--popover-foreground)",
+          "--normal-border": "var(--border)",
+        } as React.CSSProperties
+      }
+      {...props}
+    />
+  )
+}
+
+export { Toaster }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import axios, { AxiosError } from "axios";
 import type {
   RiotAccountDto,
   TftStatusDto,
@@ -12,6 +12,7 @@ import type {
   TftRenewDto,
 } from "./types";
 import { handleAxiosError } from "./utils";
+import { useErrorStore } from "@/store/errorStore"; // useErrorStore 임포트
 
 const API_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "http://127.0.0.1:8080";
 
@@ -160,8 +161,9 @@ export const findBadgesFromPuuids = async (
 // Error handling middleware
 api.interceptors.response.use(
   (response) => response,
-  (error) => {
-    // Use the new utility function to handle the error
-    throw handleAxiosError(error);
+  (error: AxiosError) => {
+    const backendError = handleAxiosError(error);
+    useErrorStore.getState().setError(backendError); // 전역 에러 스토어에 에러 설정
+    return Promise.reject(backendError); // 에러를 다시 던져서 호출자의 catch 블록으로 전달
   }
 );

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -11,6 +11,7 @@ import type {
   TftBadgeBulkResponseDto,
   TftRenewDto,
 } from "./types";
+import { handleAxiosError } from "./utils";
 
 const API_URL = process.env.NEXT_PUBLIC_API_BASE_URL || "http://127.0.0.1:8080";
 
@@ -160,9 +161,7 @@ export const findBadgesFromPuuids = async (
 api.interceptors.response.use(
   (response) => response,
   (error) => {
-    if (error.response?.data?.message) {
-      throw new Error(error.response.data.message);
-    }
-    throw error;
+    // Use the new utility function to handle the error
+    throw handleAxiosError(error);
   }
 );

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -157,3 +157,20 @@ export interface TftRenewDto {
   badges: TftBadgeDto[];
   renewedAt: string;
 }
+
+// Backend Error Handling Types
+export interface ProblemDetail {
+  type?: string;
+  title?: string;
+  status?: number;
+  detail?: string;
+  instance?: string;
+  // For custom properties that might be sent in ProblemDetail
+  [key: string]: any;
+}
+
+export interface BackendError {
+  message: string;
+  status?: number;
+  problemDetail?: ProblemDetail;
+}

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -1,6 +1,46 @@
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
+import { AxiosError } from "axios";
+import { ProblemDetail, BackendError } from "./types";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
+}
+
+export function handleAxiosError(
+  error: AxiosError<ProblemDetail | any>
+): BackendError {
+  if (error.response) {
+    const problemDetail = error.response.data as ProblemDetail;
+    const status = error.response.status;
+
+    let message = "알 수 없는 오류가 발생했습니다.";
+
+    if (problemDetail && problemDetail.detail) {
+      message = problemDetail.detail;
+    } else if (problemDetail && problemDetail.title) {
+      message = problemDetail.title;
+    } else if (error.message) {
+      message = error.message;
+    }
+
+    return {
+      message: message,
+      status: status,
+      problemDetail: problemDetail,
+    };
+  } else if (error.request) {
+    // 요청이 이루어졌으나 응답을 받지 못한 경우
+    return {
+      message:
+        "서버로부터 응답을 받지 못했습니다. 네트워크 연결을 확인해주세요.",
+      status: undefined,
+    };
+  } else {
+    // 요청을 설정하는 중에 발생한 오류
+    return {
+      message: `요청을 보내는 중 오류가 발생했습니다: ${error.message}`,
+      status: undefined,
+    };
+  }
 }

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -10,37 +10,40 @@ export function cn(...inputs: ClassValue[]) {
 export function handleAxiosError(
   error: AxiosError<ProblemDetail | any>
 ): BackendError {
-  if (error.response) {
-    const problemDetail = error.response.data as ProblemDetail;
-    const status = error.response.status;
+  let userFriendlyMessage: string = "An unexpected error occurred.";
+  let status: number | undefined = undefined;
+  let problemDetail: ProblemDetail | undefined = undefined;
 
-    let message = "알 수 없는 오류가 발생했습니다.";
+  if (error.response) {
+    problemDetail = error.response.data as ProblemDetail;
+    status = error.response.status;
 
     if (problemDetail && problemDetail.detail) {
-      message = problemDetail.detail;
+      // Prioritize backend detail message if available and user-friendly
+      userFriendlyMessage = problemDetail.detail;
     } else if (problemDetail && problemDetail.title) {
-      message = problemDetail.title;
+      // Fallback to title if detail is not available
+      userFriendlyMessage = problemDetail.title;
+    } else if (status && status >= 500) {
+      // Generic message for server errors
+      userFriendlyMessage =
+        "Our server is experiencing issues. Please try again later.";
     } else if (error.message) {
-      message = error.message;
+      // Fallback to axios error message
+      userFriendlyMessage = error.message;
     }
-
-    return {
-      message: message,
-      status: status,
-      problemDetail: problemDetail,
-    };
   } else if (error.request) {
-    // 요청이 이루어졌으나 응답을 받지 못한 경우
-    return {
-      message:
-        "서버로부터 응답을 받지 못했습니다. 네트워크 연결을 확인해주세요.",
-      status: undefined,
-    };
+    // The request was made but no response was received (e.g., network error)
+    userFriendlyMessage =
+      "Network error: Could not connect to the server. Please check your internet connection.";
   } else {
-    // 요청을 설정하는 중에 발생한 오류
-    return {
-      message: `요청을 보내는 중 오류가 발생했습니다: ${error.message}`,
-      status: undefined,
-    };
+    // Something happened in setting up the request that triggered an Error
+    userFriendlyMessage = `An error occurred while setting up the request: ${error.message}`;
   }
+
+  return {
+    message: userFriendlyMessage,
+    status: status,
+    problemDetail: problemDetail,
+  };
 }

--- a/web/src/store/errorStore.ts
+++ b/web/src/store/errorStore.ts
@@ -1,0 +1,12 @@
+import { create } from "zustand";
+import { BackendError } from "../lib/types";
+
+interface ErrorState {
+  error: BackendError | null;
+  setError: (error: BackendError | null) => void;
+}
+
+export const useErrorStore = create<ErrorState>((set) => ({
+  error: null,
+  setError: (error) => set({ error }),
+}));


### PR DESCRIPTION
# 프론트엔드 에러 처리 연동 및 백엔드 API 문서화 개선

## 개요

프론트엔드에서 백엔드의 표준화된 에러 응답을 효과적으로 처리하고, 백엔드 API의 문서화를 개선하여 개발 생산성과 사용자 경험을 향상시켰습니다. 백엔드의 `ProblemDetail` 기반 에러 응답을 프론트엔드에서 일관되게 처리하고, OpenAPI(Swagger) 문서화를 통해 API 명세를 자동화했습니다.

## 주요 변경사항

### 1. 프론트엔드 에러 처리 개선
- 전역 에러 처리를 위한 상태 관리 추가:
  - `web/src/store/errorStore.ts` 생성
  - `BackendError` 타입 정의 및 에러 상태 관리 로직 구현
- 에러 토스트 컴포넌트 구현:
  - `web/src/components/ErrorToastDisplay.tsx` 추가
  - Sonner 라이브러리를 활용한 토스트 메시지 표시
- API 에러 처리 로직 개선:
  - `web/src/lib/utils.ts`에 `handleAxiosError` 유틸리티 함수 추가
  - Axios 인터셉터를 통한 전역 에러 처리 구현

### 2. 백엔드 OpenAPI 문서화
- Swagger 의존성 및 설정 추가:
  - `springdoc-openapi-starter-webmvc-ui` 의존성 추가
  - `OpenApiConfig` 클래스 생성 및 기본 설정
- 컨트롤러 문서화:
  - `@Tag`, `@Operation`, `@ApiResponse` 어노테이션 추가
  - 모든 주요 컨트롤러(Riot, Rivalry, TFT 관련)에 API 설명 추가
- DTO 문서화:
  - `@Schema` 어노테이션을 통한 DTO 필드 설명 추가
  - 모든 요청/응답 DTO에 상세한 필드 설명 포함

### 3. 사용자 경험 개선
- 소환사 검색 실패 시 명확한 에러 메시지 표시
- API 호출 실패 시 사용자 친화적인 토스트 메시지 제공
- 로딩 및 에러 상태에 대한 UI 피드백 개선

## 관련 이슈
Resolved #40 